### PR TITLE
Fix ccx visibility on catalog

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -290,6 +290,9 @@ def _can_enroll_courselike(user, courselike):
     if _has_staff_access_to_descriptor(user, courselike, course_key):
         return ACCESS_GRANTED
 
+    if _is_ccx_course(courselike):
+        return ACCESS_DENIED
+
     if courselike.invitation_only:
         debug("Deny: invitation only")
         return ACCESS_DENIED
@@ -350,9 +353,13 @@ def _has_access_course(user, action, courselike):
     def see_exists():
         """
         Can see if can enroll, but also if can load it: if user enrolled in a course and now
-        it's past the enrollment period, they should still see it.
+        it's past the enrollment period, they should still see it. CCX courses are hidden.
         """
-        return ACCESS_GRANTED if (can_load() or can_enroll()) else ACCESS_DENIED
+        return (
+            ACCESS_GRANTED
+            if (not _is_ccx_course(courselike) and (can_load() or can_enroll()))
+            else ACCESS_DENIED
+        )
 
     def can_see_in_catalog():
         """
@@ -361,8 +368,10 @@ def _has_access_course(user, action, courselike):
         but also allow course staff to see this.
         """
         return (
-            _has_catalog_visibility(courselike, CATALOG_VISIBILITY_CATALOG_AND_ABOUT)
-            or _has_staff_access_to_descriptor(user, courselike, courselike.id)
+            not _is_ccx_course(courselike) and (
+                _has_catalog_visibility(courselike, CATALOG_VISIBILITY_CATALOG_AND_ABOUT)
+                or _has_staff_access_to_descriptor(user, courselike, courselike.id)
+            )
         )
 
     def can_see_about_page():
@@ -824,6 +833,13 @@ def _is_descriptor_mobile_available(descriptor):
         return ACCESS_GRANTED
     else:
         return MobileAvailabilityError()
+
+
+def _is_ccx_course(courselike):
+    """
+    Returns if the courselike is a ccx course.
+    """
+    return isinstance(courselike.id, CCXLocator)
 
 
 def is_mobile_available_for_user(user, descriptor):

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -849,3 +849,79 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
         course_overview = CourseOverview.get_from_id(course.id)
         with self.assertNumQueries(num_queries):
             bool(access.has_access(user, action, course_overview, course_key=course.id))
+
+
+@ddt.ddt
+class CCXTestCase(SharedModuleStoreTestCase):
+    """
+    Tests for ccx course visibility
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        """
+        Set up tests
+        """
+        super(CCXTestCase, self).setUp()
+
+        course = CourseFactory.create(enable_ccx=True)
+        CourseOverview.load_from_module_store(course.id)
+        self.course = course
+
+        student = UserFactory.create()
+        staff = AdminFactory.create()
+        coach = UserFactory.create()
+
+        ccx = CustomCourseForEdX(
+            course_id=course.id,
+            coach=coach,
+            display_name="Test CCX"
+        )
+        ccx.save()
+        self.ccx_overview = CourseOverview.get_from_id(ccx.locator)
+
+        self.users = {
+            'coach': coach,
+            'student': student,
+            'staff': staff,
+        }
+
+    @ddt.data(
+        ('student', 'see_in_catalog', True),
+        ('student', 'see_exists', True),
+    )
+    @ddt.unpack
+    def test_base_course_visibility(self, username, permission, has_permission):
+        """
+        Test base course visibility is as expected
+        """
+        user = self.users[username]
+        self.assertEqual(bool(access.has_access(user, permission, self.course)), has_permission)
+
+    @ddt.data(
+        ('student', 'see_in_catalog', False),
+        ('student', 'see_exists', False),
+        ('student', 'enroll', False),
+        # load permission is required because other areas in the code need it.
+        ('student', 'load', True),
+        ('student', 'see_about_page', True),
+
+        ('coach', 'see_in_catalog', False),
+        ('coach', 'see_exists', False),
+        ('coach', 'enroll', False),
+        ('coach', 'load', True),
+        ('coach', 'see_about_page', True),
+
+        ('staff', 'see_in_catalog', False),
+        ('staff', 'see_exists', False),
+        ('staff', 'enroll', True),
+        ('staff', 'load', True),
+        ('staff', 'see_about_page', True),
+    )
+    @ddt.unpack
+    def test_ccx_visibility(self, username, permission, has_permission):
+        """
+        Test ccx course visibility is as expected
+        """
+        user = self.users[username]
+        self.assertEqual(bool(access.has_access(user, permission, self.ccx_overview)), has_permission)


### PR DESCRIPTION
This PR hides all ccx courses from the course catalog. Previously the catalog visibility was inherited from the base course at the time of ccx creation, resulting in the possibility of ccx courses to be unexpectedly visible in the catalog.

**Dependencies**: None

**Sandbox URL**:

-    LMS: TBD
-    Studio: TBD

**Merge deadline**: None

**Testing instructions**:

1. Enable CCX courses (`CUSTOM_COURSES_EDX: true`)
2. go through the process of [creating a custom course](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/set_up_course/studio_add_course_information/custom_courses.html).
3. log in as a non-staff user and view the course catalog page. the ccx course overview should not be seen.
4. also test with `COURSE_CATALOG_VISIBILITY_PERMISSION` set to `see_in_catalog`

**Author notes and concerns**:

- The default catalog/about visibility permissions are `see_exists`, which renders the `catalog_visibility` advanced course setting useless.


**Settings**
```yaml
EDXAPP_FEATURES:
    CUSTOM_COURSES_EDX: true
```