### PR TITLE
[SE-1199] Fix username hints for SSO

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -9,7 +9,7 @@ If true, it:
     a) loads this module.
     b) calls apply_settings(), passing in the Django settings
 """
-
+from django.conf import settings
 from openedx.features.enterprise_support.api import insert_enterprise_pipeline_elements
 
 _FIELDS_STORED_IN_SESSION = ['auth_entry', 'next']
@@ -42,7 +42,7 @@ def apply_settings(django_settings):
     django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = _SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS
 
     # Avoid default username check to allow non-ascii characters
-    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = False
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.FEATURES.get("ENABLE_UNICODE_USERNAME")
 
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -41,6 +41,9 @@ def apply_settings(django_settings):
     # Adding extra key value pair in the url query string for microsoft as per request
     django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = _SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS
 
+    # Avoid default username check to allow non-ascii characters
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = False
+
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.
     django_settings.SOCIAL_AUTH_PIPELINE = [

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -56,3 +56,9 @@ class SettingsUnitTest(testutil.TestCase):
         # bad in prod.
         settings.apply_settings(self.settings)
         self.assertFalse(self.settings.SOCIAL_AUTH_RAISE_EXCEPTIONS)
+
+    def test_apply_settings_avoids_default_username_check(self):
+        # Avoid the default username check where non-ascii characters are not
+        # allowed
+        settings.apply_settings(self.settings)
+        self.assertFalse(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES)


### PR DESCRIPTION
This PR fixes the issue of the username hints not working for SSO - Google, FB, SAML.
The fix essentially disables calling the default clean username method which filters out non-ascii characters.

**Testing Instructions:**
1. Go to https://courses.campus-dev.opencraft.hosting/register?next=/dashboard and login with either MOE SSO/FB/Google credentials.
2. Verify that the username field being auto-filled is correct.

Reviewers:
@pomegranited 