### PR TITLE
[SE-1199] Fix username hints for SSO

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -13,11 +13,11 @@ If true, it:
 from openedx.features.enterprise_support.api import insert_enterprise_pipeline_elements
 
 _FIELDS_STORED_IN_SESSION = ['auth_entry', 'next']
-_MIDDLEWARE_CLASSES = (
-    'third_party_auth.middleware.ExceptionMiddleware',
-    'third_party_auth.middleware.PipelineQuarantineMiddleware',
-)
+_MIDDLEWARE_CLASSES = ['third_party_auth.middleware.ExceptionMiddleware']
 _SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/dashboard'
+_SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
+    'msafed': 0
+}
 
 
 def apply_settings(django_settings):
@@ -28,7 +28,7 @@ def apply_settings(django_settings):
     django_settings.FIELDS_STORED_IN_SESSION = _FIELDS_STORED_IN_SESSION
 
     # Inject exception middleware to make redirects fire.
-    django_settings.MIDDLEWARE_CLASSES += _MIDDLEWARE_CLASSES
+    django_settings.MIDDLEWARE_CLASSES.extend(_MIDDLEWARE_CLASSES)
 
     # Where to send the user if there's an error during social authentication
     # and we cannot send them to a more specific URL
@@ -37,6 +37,12 @@ def apply_settings(django_settings):
 
     # Where to send the user once social authentication is successful.
     django_settings.SOCIAL_AUTH_LOGIN_REDIRECT_URL = _SOCIAL_AUTH_LOGIN_REDIRECT_URL
+
+    # Adding extra key value pair in the url query string for microsoft as per request
+    django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = _SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS
+
+    # Avoid default username check to allow non-ascii characters
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = False
 
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.
@@ -54,6 +60,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.associate_user',
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',
+        'third_party_auth.pipeline.user_details_force_sync',
         'third_party_auth.pipeline.set_logged_in_cookies',
         'third_party_auth.pipeline.login_analytics',
     ]

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -65,7 +65,9 @@ class SettingsUnitTest(testutil.TestCase):
 
     def test_apply_settings_avoids_default_username_check(self):
         # Avoid the default username check where non-ascii characters are not
-        # allowed
+        # allowed when unicode username is enabled
+        settings.apply_settings(self.settings)
+        self.assertTrue(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES) # verify default behavior
         with patch.dict('django.conf.settings.FEATURES', {'ENABLE_UNICODE_USERNAME': True}):
             settings.apply_settings(self.settings)
             self.assertFalse(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES)

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from mock import patch
 from openedx.features.enterprise_support.api import enterprise_enabled
 from third_party_auth import provider, settings
 from third_party_auth.tests import testutil
@@ -61,3 +62,10 @@ class SettingsUnitTest(testutil.TestCase):
     def test_enterprise_elements_inserted(self):
         settings.apply_settings(self.settings)
         self.assertIn('enterprise.tpa_pipeline.handle_enterprise_logistration', self.settings.SOCIAL_AUTH_PIPELINE)
+
+    def test_apply_settings_avoids_default_username_check(self):
+        # Avoid the default username check where non-ascii characters are not
+        # allowed
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_UNICODE_USERNAME': True}):
+            settings.apply_settings(self.settings)
+            self.assertFalse(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES)


### PR DESCRIPTION
This PR fixes the issue of the username hints not working for SSO - Google, FB, SAML.
The fix essentially disables calling the default clean username method which filters out non-ascii characters.

**Testing Instructions:**

1. Go to https://courses.campus-dev.opencraft.hosting/register?next=/dashboard and login with either MOE SSO/FB/Google credentials.
2. Verify that the username field being auto-filled is correct.

Reviewers:
@pomegranited