### PR TITLE
[SE-1205] Update Github archived requirements with forked repositories

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -48,26 +48,26 @@
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
 git+https://github.com/open-craft/django-wiki.git@v0.0.10.1#egg=django-wiki==0.0.10.1
-git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
+git+https://github.com/open-craft/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
-git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
+git+https://github.com/open-craft/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
--e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
+-e git+https://github.com/open-craft/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/django-cas.git@v2.1.1#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 # Master pyfs has a bug working with VPC auth. This is a fix. We should switch
 # back to master when and if this fix is merged back.
 # fs==0.4.0
-git+https://github.com/edx/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b#egg=fs==0.4.0
+git+https://github.com/open-craft/pyfs.git@96e1922348bfe6d99201b9512a9ed946c87b7e0b#egg=fs==0.4.0
 # The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 
 # NOTE (CCB): This must remain. There is one commit on the upstream repo that has not been released to PyPI.
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
+git+https://github.com/open-craft/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 
 # Used for testing
-git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
+git+https://github.com/open-craft/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0


### PR DESCRIPTION
This PR updates Github requirements to use `open-craft` forks to avoid the risk of deleted repositories.

**Dev URL:**
- LMS: https://courses.campus-dev.opencraft.hosting/
- Studio: https://studio.campus-dev.opencraft.hosting/

**Reviewers**
- @pomegranited 