### PR TITLE
SE-1155 Allows unicode usernames to be used in CCX enrollments and reports.

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -86,7 +86,7 @@ def setup_students_and_grades(context):
         context.student = student = UserFactory.create()
         CourseEnrollmentFactory.create(user=student, course_id=context.course.id)
 
-        context.student2 = student2 = UserFactory.create()
+        context.student2 = student2 = UserFactory.create(username=u'u\u0131\u028c\u0279\u0250\u026f')
         CourseEnrollmentFactory.create(user=student2, course_id=context.course.id)
 
         # create grades for self.student as if they'd submitted the ccx

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -202,7 +202,7 @@ def get_valid_student_with_email(identifier):
     try:
         validate_email(email)
     except ValidationError:
-        raise CCXUserValidationException('Could not find a user with name or email "{0}" '.format(identifier))
+        raise CCXUserValidationException(u'Could not find a user with name or email "{0}" '.format(identifier))
     return email, user
 
 

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -236,14 +236,14 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
                 if student:
                     must_enroll = student in staff or student in admins or student == coach
             except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
+                log.info(u"%s", exp)
+                errors.append(u"{0}".format(exp))
                 continue
 
             if CourseEnrollment.objects.is_course_full(ccx_course_overview) and not must_enroll:
                 error = _('The course is full: the limit is {max_student_enrollments_allowed}').format(
                     max_student_enrollments_allowed=ccx_course_overview.max_student_enrollments_allowed)
-                log.info("%s", error)
+                log.info(u"%s", error)
                 errors.append(error)
                 break
             enroll_email(course_key, email, auto_enroll=True, email_students=email_students, email_params=email_params)
@@ -252,8 +252,8 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
             try:
                 email, __ = get_valid_student_with_email(identifier)
             except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
+                log.info(u"%s", exp)
+                errors.append(u"{0}".format(exp))
                 continue
             unenroll_email(course_key, email, email_students=email_students, email_params=email_params)
     return errors

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -561,7 +561,8 @@ def ccx_grades_csv(request, course, ccx=None):
                 }
 
                 row_percents = [percents.get(label, 0.0) for label in header]
-                rows.append([student.id, student.email, student.username,
+                rows.append([student.id, student.email.encode('utf-8'),
+                             student.username.encode('utf-8'),
                              course_grade.percent] + row_percents)
 
         buf = StringIO()


### PR DESCRIPTION
Previously, unicode would result in a UnicodeEncodeError as a result of
the format string being str instead of unicode.

Additionally, the log calls would crash with a traceback (while not
affecting the program flow).

(cherry picked from commit 54f9434d468be65bd925628a8812bf33349582ca)

**Sandbox**:

-    LMS: https://pr11.sandbox.opencraft.hosting/
-    Studio: https://studio.pr11.sandbox.opencraft.hosting/

**Testing**:

See https://github.com/edx/edx-platform/pull/21248


**Settings**
```yaml
EDXAPP_FEATURES:
  CUSTOM_COURSES_EDX: true
  ENABLE_UNICODE_USERNAME: true
```