### PR TITLE
SE-1499 Merge security patch to Campus Ginkgo.2 branch

### DIFF
--- a/common/lib/xmodule/xmodule/template_module.py
+++ b/common/lib/xmodule/xmodule/template_module.py
@@ -1,8 +1,9 @@
 """
 Template module
 """
+from string import Template
+
 from lxml import etree
-from mako.template import Template
 
 import dogstats_wrapper as dog_stats_api
 from xmodule.raw_module import RawDescriptor
@@ -14,8 +15,9 @@ class CustomTagModule(XModule):
     This module supports tags of the form
     <customtag option="val" option2="val2" impl="tagname"/>
 
-    In this case, $tagname should refer to a file in data/custom_tags, which contains
-    a mako template that uses ${option} and ${option2} for the content.
+    In this case, $tagname should refer to a file in data/custom_tags, which
+    contains a Python string.Template formatted template that uses ${option} and
+    ${option2} for the content.
 
     For instance:
 
@@ -69,7 +71,7 @@ class CustomTagDescriptor(RawDescriptor):
         template_module = system.load_item(template_loc)
         template_module_data = template_module.data
         template = Template(template_module_data)
-        return template.render(**params)
+        return template.safe_substitute(params)
 
     @property
     def rendered_html(self):


### PR DESCRIPTION
Includes the following patches from https://github.com/open-craft/edx-platform/pull/187 and https://github.com/open-craft/edx-platform/pull/189

* Mako fix (https://github.com/edx/edx-platform/pull/21350) -- clean cherry-pick

**Testing instructions**

Will deploy to stage.campus.gov.il to test.

**Author Notes & Concerns**

Omitted these patches because they are not required for Campus Ginkgo.2:

* [Google cloud API removal](https://github.com/edx/edx-platform/commit/3136b3ecd3bc0d375e8e3f47f850805dc19b70db) and related [YouTube API Referrer fix](https://github.com/open-craft/edx-platform/pull/189/commits/1331d3dfb8ee4a7f65340914786951e12b50c6ed):  `YOUTUBE_API_KEY` not set for Olive edxapp services.
* [Social link platform validation](https://github.com/edx/edx-platform/commit/138b3b35e039ae5a6a059335ec65182977901837): `SocialLink` model not in Ginkgo.2

**Reviewer**
- [ ] @clemente 