### PR TITLE
SE-1740 Adds rel="noopener" to target="_blank" links

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -70,7 +70,10 @@ require([
 
             // general link management - new window/tab
             $('a[rel="external"]:not([title])').attr('title', gettext('This link will open in a new browser window/tab'));
-            $('a[rel="external"]').attr('target', '_blank');
+            $('a[rel="external"]').attr({
+              rel: 'noopener external', 
+              target: '_blank'
+            });
 
             // general link management - lean modal window
             $('a[rel="modal"]').attr('title', gettext('This link will open in a modal window')).leanModal({

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -80,7 +80,7 @@
                 <p>${_("To copy a URL, double click the value in the URL column, then copy the selected text.")}</p>
             </div>
             <div class="bit external-help">
-                <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about managing files")}</a>
+                <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about managing files")}</a>
             </div>
 
         </aside>

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -94,7 +94,7 @@ CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
             <h3 class="title-3">${_("Issuing Certificates to Learners")}</h3>
             <p>${_("To begin issuing course certificates, a course team member with either the Staff or Admin role selects {em_start}Activate{em_end}. Only course team members with these roles can edit or delete an activated certificate.").format(em_start="<strong>", em_end="</strong>")}</p>
             <p>${_("{em_start}Do not{em_end} delete certificates after a course has started; learners who have already earned certificates will no longer be able to access them.").format(em_start="<strong>", em_end="</strong>")}</p>
-            <p><a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about certificates")}</a></p>
+            <p><a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about certificates")}</a></p>
           </div>
         </div>
         <div class="bit">

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -134,7 +134,7 @@ from openedx.core.djangolib.markup import HTML, Text
                         <p>${_("Confirm that you have properly configured content in each of your experiment groups.")}</p>
                     </div>
                     <div class="bit external-help">
-                        <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about component containers")}</a>
+                        <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about component containers")}</a>
                     </div>
                 % elif is_unit_page:
                     <div id="publish-unit"></div>

--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -148,7 +148,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
           </div>
 
           <div class="bit external-help">
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about Course Re-runs")}</a>
+            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about Course Re-runs")}</a>
           </div>
         </aside>
 

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -201,14 +201,14 @@ from openedx.core.djangolib.markup import HTML, Text
                 <h3 class="title-3">${_("Reorganizing your course")}</h3>
                 <p>${_("Drag sections, subsections, and units to new locations in the outline.")}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('outline')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about the course outline")}</a>
+                    <a href="${get_online_help_info('outline')['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about the course outline")}</a>
                 </div>
             </div>
             <div class="bit">
                 <h3 class="title-3">${_("Setting release dates and grading policies")}</h3>
                 <p>${_("Select the Configure icon for a section or subsection to set its release date. When you configure a subsection, you can also set the grading policy and due date.")}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('grading')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about grading policy settings")}</a>
+                    <a href="${get_online_help_info('grading')['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about grading policy settings")}</a>
                 </div>
             </div>
             <div class="bit">
@@ -217,7 +217,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 <p>${Text(_("To make a section, subsection, or unit unavailable to learners, select the Configure icon for that level, then select the appropriate {em_start}Hide{em_end} option. Grades for hidden sections, subsections, and units are not included in grade calculations.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
                 <p>${Text(_("To hide the content of a subsection from learners after the subsection due date has passed, select the Configure icon for a subsection, then select {em_start}Hide content after due date{em_end}. Grades for the subsection remain included in grade calculations.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('visibility')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content visibility settings")}</a>
+                    <a href="${get_online_help_info('visibility')['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about content visibility settings")}</a>
                 </div>
             </div>
 

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -235,7 +235,7 @@ else:
           <p>${_("Use an archive program to extract the data from the .tar.gz file. Extracted data includes the library.xml file, as well as subfolders that contain library content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about exporting a library")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about exporting a library")}</a>
       </div>
     </aside>
   %else:
@@ -259,7 +259,7 @@ else:
         <p>${_("Use an archive program to extract the data from the .tar.gz file. Extracted data includes the course.xml file, as well as subfolders that contain course content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about exporting a course")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about exporting a course")}</a>
       </div>
     </aside>
   %endif

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -86,7 +86,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <p>${_("Enrollment track groups allow you to offer different course content to learners in each enrollment track. Learners enrolled in each enrollment track in your course are automatically included in the corresponding enrollment track group.")}</p>
             <p>${_("On unit pages in the course outline, you can restrict access to components to learners based on their enrollment track.")}</p>
             <p>${_("You cannot edit enrollment track groups, but you can expand each group to view details of the course content that is designated for learners in the group.")}</p>
-            <p><a href="${get_online_help_info(enrollment_track_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+            <p><a href="${get_online_help_info(enrollment_track_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % endif
@@ -96,7 +96,7 @@ from openedx.core.djangolib.markup import HTML, Text
               <p>${_("If you have cohorts enabled in your course, you can use content groups to create cohort-specific courseware. In other words, you can customize the content that particular cohorts see in your course.")}</p>
               <p>${_("Each content group that you create can be associated with one or more cohorts. In addition to making course content available to all learners, you can restrict access to some content to learners in specific content groups. Only learners in the cohorts that are associated with the specified content groups see the additional content.")}</p>
               <p>${Text(_("Click {em_start}New content group{em_end} to add a new content group. To edit the name of a content group, hover over its box and click {em_start}Edit{em_end}. You can delete a content group only if it is not in use by a unit. To delete a content group, hover over its box and click the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
-              <p><a href="${get_online_help_info(content_groups_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+              <p><a href="${get_online_help_info(content_groups_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % if should_show_experiment_groups:
@@ -105,7 +105,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <h3 class="title-3">${_("Experiment Group Configurations")}</h3>
             <p>${_("Use experiment group configurations if you are conducting content experiments, also known as A/B testing, in your course. Experiment group configurations define how many groups of learners are in a content experiment. When you create a content experiment for a course, you select the group configuration to use.")}</p>
             <p>${Text(_("Click {em_start}New Group Configuration{em_end} to add a new configuration. To edit a configuration, hover over its box and click {em_start}Edit{em_end}. You can delete a group configuration only if it is not in use in an experiment. To delete a configuration, hover over its box and click the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
-            <p><a href="${get_online_help_info(experiment_group_configurations_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+            <p><a href="${get_online_help_info(experiment_group_configurations_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % endif

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -213,7 +213,7 @@ else:
           <p>${_("If you change and import a library that is referenced by randomized content blocks in one or more courses, those courses do not automatically use the updated content. You must manually refresh the randomized content blocks to bring them up to date with the latest library content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about importing a library")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about importing a library")}</a>
       </div>      
     </aside>
   %else:
@@ -233,7 +233,7 @@ else:
         <p>${_("If you perform an import while your course is running, and you change the URL names (or url_name nodes) of any Problem components, the student data associated with those Problem components may be lost. This data includes students' problem scores.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about importing a course")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about importing a course")}</a>
       </div>      
     </aside>
   %endif

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -536,7 +536,7 @@ from openedx.core.djangolib.markup import HTML, Text
         <ol class="list-actions">
           <li class="action-item">
 
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
+            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>

--- a/cms/templates/js/add-xblock-component-support-legend.underscore
+++ b/cms/templates/js/add-xblock-component-support-legend.underscore
@@ -1,7 +1,7 @@
 <% if (support_legend.show_legend) { %>
     <span class="support-documentation">
         <a class="support-documentation-link"
-           href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" target="_blank">
+           href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" target="_blank" rel="noopener">
             <%- support_legend.documentation_label %>
         </a>
         <span class="support-documentation-level">

--- a/cms/templates/js/certificate-web-preview.underscore
+++ b/cms/templates/js/certificate-web-preview.underscore
@@ -4,7 +4,7 @@
      <option value= "<%= course_mode %>"><%= course_mode %></option>
 <% }); %>
 </select>
-<a href=<%= certificate_web_view_url %> class="button preview-certificate-link" target="_blank">
+<a href=<%= certificate_web_view_url %> class="button preview-certificate-link" target="_blank" rel="noopener">
     <%= gettext("Preview Certificate") %>
 </a>
 <button class="button activate-cert">

--- a/cms/templates/js/license-selector.underscore
+++ b/cms/templates/js/license-selector.underscore
@@ -3,7 +3,7 @@
         <%= gettext("License Type") %>
     </h3>
     <ul class="license-types">
-        <% var link_start_tpl = '<a href="{url}" target="_blank">'; %>
+        <% var link_start_tpl = '<a href="{url}" target="_blank" rel="noopener">'; %>
         <% _.each(licenseInfo, function(license, licenseType) { %>
             <li class="license-type" data-license="<%- licenseType %>">
                 <button name="license-<%- licenseType %>"
@@ -14,7 +14,7 @@
                 </button>
                 <p class="tip">
                     <% if(license.url) { %>
-                        <a href="<%- license.url %>" target="_blank">
+                        <a href="<%- license.url %>" target="_blank" rel="noopener">
                             <%= gettext("Learn more about {license_name}")
                                         .replace("{license_name}", license.name)
                             %>

--- a/cms/templates/js/metadata-file-uploader-item.underscore
+++ b/cms/templates/js/metadata-file-uploader-item.underscore
@@ -1,3 +1,3 @@
 <a href="#" class="upload-action upload-setting"><%= model.get('value') ? gettext('Replace') : gettext('Upload') %>
-</a><% if (model.get('value')) { %><a href="<%= model.get("value") %>" target="_blank" class="download-action download-setting"><%= gettext("Download") %>
+</a><% if (model.get('value')) { %><a href="<%= model.get("value") %>" target="_blank" rel="noopener" class="download-action download-setting"><%= gettext("Download") %>
 </a><% } %>

--- a/cms/templates/js/mock/mock-unit-page.underscore
+++ b/cms/templates/js/mock/mock-unit-page.underscore
@@ -4,7 +4,7 @@
         <div class="inner-wrapper">
             <div class="alert editing-draft-alert">
                 <p class="alert-message"><strong>You are editing a draft.</strong></p>
-                <a href="#" target="_blank" class="alert-action secondary">View the Live Version</a>
+                <a href="#" target="_blank" rel="noopener" class="alert-action secondary">View the Live Version</a>
             </div>
 
             <div class="main-column">

--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -98,7 +98,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 </div>
                 % endif
                 <div class="bit external-help">
-                    <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
+                    <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about content libraries")}</a>
                 </div>
             </div>
         </div>

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -67,7 +67,7 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE}"
         </div>
 
         <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about textbooks")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" rel="noopener" class="button external-help-button">${_("Learn more about textbooks")}</a>
         </div>
       </aside>
     </section>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -215,7 +215,7 @@
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a></span></h3>
+            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank" rel="noopener">${_("Help")}</a></span></h3>
           </li>
           <li class="nav-item nav-account-user">
             <%include file="user_dropdown.html" args="online_help_token=online_help_token" />
@@ -228,7 +228,7 @@
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-not-signedin-help">
-            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a>
+            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank" rel="noopener">${_("Help")}</a>
           </li>
           % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
               <li class="nav-item nav-not-signedin-signup">

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -78,7 +78,7 @@ from xmodule.x_module import XModule, module_attr
 log = logging.getLogger(__name__)
 
 DOCS_ANCHOR_TAG_OPEN = (
-    "<a target='_blank' "
+    "<a target='_blank' rel='noopener external' "
     "href='http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html'>"
 )
 

--- a/common/lib/xmodule/xmodule/templates/html/iframe.yaml
+++ b/common/lib/xmodule/xmodule/templates/html/iframe.yaml
@@ -20,7 +20,7 @@ data: |
       <li>Replace the value of the <strong>src</strong> attribute of the IFrame with the URL of the tool that you want in your course.
       <p><strong>Note</strong>: The URL must start with <strong>https</strong> instead of http, to ensure that the tool appears in all browsers that support IFrames.</p></li>
       <li>Replace the value of the <strong>title</strong> attribute with the title of the tool. You <strong>must</strong> include the title to provide an accessible label.</li>
-      <li>Replace other IFrame attributes as needed. See <a href="http://www.w3.org/wiki/HTML/Elements/iframe" target="_blank">the IFrame specification</a> for more information.</li>
+      <li>Replace other IFrame attributes as needed. See <a href="http://www.w3.org/wiki/HTML/Elements/iframe" target="_blank" rel="noopener external">the IFrame specification</a> for more information.</li>
       <li>Optionally, replace the text between the opening and closing <strong>iframe</strong> tags.
           <pre>Your browser does not support IFrames.</pre>
           <p>A learner sees this text if the browser does not support IFrames.</p>

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -85,14 +85,14 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         Returns expected dashboard enrollment message with link to Insights.
         """
         return 'Enrollment data is now available in <a href="http://example.com/courses/{}" ' \
-               'target="_blank">Example</a>.'.format(unicode(self.course.id))
+               'target="_blank" rel="noopener">Example</a>.'.format(unicode(self.course.id))
 
     def get_dashboard_analytics_message(self):
         """
         Returns expected dashboard demographic message with link to Insights.
         """
         return 'For analytics about your course, go to <a href="http://example.com/courses/{}" ' \
-               'target="_blank">Example</a>.'.format(unicode(self.course.id))
+               'target="_blank" rel="noopener">Example</a>.'.format(unicode(self.course.id))
 
     def test_instructor_tab(self):
         """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -134,7 +134,7 @@ def instructor_dashboard_2(request, course_id):
     if show_analytics_dashboard_message(course_key):
         # Construct a URL to the external analytics dashboard
         analytics_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
-        link_start = HTML("<a href=\"{}\" target=\"_blank\">").format(analytics_dashboard_url)
+        link_start = HTML("<a href=\"{}\" target=\"_blank\" rel=\"noopener\">").format(analytics_dashboard_url)
         analytics_dashboard_message = _(
             "To gain insights into student enrollment and participation {link_start}"
             "visit {analytics_dashboard_name}, our new course analytics product{link_end}."
@@ -695,7 +695,7 @@ def _section_send_email(course, access):
 def _get_dashboard_link(course_key):
     """ Construct a URL to the external analytics dashboard """
     analytics_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
-    link = HTML(u"<a href=\"{0}\" target=\"_blank\">{1}</a>").format(
+    link = HTML(u"<a href=\"{0}\" target=\"_blank\" rel=\"noopener\">{1}</a>").format(
         analytics_dashboard_url, settings.ANALYTICS_DASHBOARD_NAME
     )
     return link

--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -488,7 +488,7 @@
                     cssClass: 'file-download-link',
                     formatter: function(row, cell, value, columnDef, dataContext) {
                         return edx.HtmlUtils.joinHtml(edx.HtmlUtils.HTML(
-                            '<a target="_blank" href="'), dataContext.url,
+                            '<a target="_blank" rel="noopener" href="'), dataContext.url,
                             edx.HtmlUtils.HTML('">'), dataContext.name,
                             edx.HtmlUtils.HTML('</a>'));
                     }

--- a/lms/templates/api_admin/catalogs/edit.html
+++ b/lms/templates/api_admin/catalogs/edit.html
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext as _
   <h1 id="api-header">${catalog.name}</h1>
 
   <p>
-    <a href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}" target="_blank">
+    <a href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}" target="_blank" rel="noopener">
       ${_("Download CSV")}
     </a>
   </p>

--- a/lms/templates/api_admin/catalogs/list.html
+++ b/lms/templates/api_admin/catalogs/list.html
@@ -28,7 +28,7 @@ CatalogPreviewFactory({
       <a href="${reverse('api_admin:catalog-edit', args=(catalog.id,))}">${catalog.name}</a>&nbsp;
       (<a
           href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}"
-          target="_blank">${_("Download CSV")}</a>)
+          target="_blank" rel="noopener">${_("Download CSV")}</a>)
     </li>
     % endfor
   </ul>

--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -24,7 +24,7 @@ from django.template.defaultfilters import escapejs
                   social_network: 'LinkedIn'
               };
               Logger.log('edx.certificate.shared', data);
-              window.open('${linked_in_url}');
+              window.open('${linked_in_url}', '', 'noopener');
           });
       });
 
@@ -32,7 +32,9 @@ from django.template.defaultfilters import escapejs
           // popup a window at center of the screen.
           var left = (screen.width/2)-(width/2);
           var top = (screen.height/2)-(height/2);
-          return window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width='+width+', height='+height+', top='+top+', left='+left);
+          var popupWindow = window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width='+width+', height='+height+', top='+top+', left='+left);
+          popupWindow.opener = null;
+          return popupWindow;
       }
   </script>
 </%block>

--- a/lms/templates/certificates/_badges-modal.html
+++ b/lms/templates/certificates/_badges-modal.html
@@ -12,9 +12,9 @@
         <hr class="modal-hr"/>
         <img class="backpack-logo" src="${static.url('certificates/images/backpack-logo.png')}">
         <ol class="badges-steps">
-            <li class="step">Create a <a href="https://backpack.openbadges.org/" target="_blank">Mozilla Backpack</a> account, or log in to your existing account
+            <li class="step">Create a <a href="https://backpack.openbadges.org/" target="_blank" rel="noopener external">Mozilla Backpack</a> account, or log in to your existing account
             </li>
-            <li class="step"><a href="${badge.image_url}" target="_blank">Download this image (right-click, save as)</a> and then <a href="https://backpack.openbadges.org/backpack/add" target="_blank">upload</a> it to your backpack.</li>
+            <li class="step"><a href="${badge.image_url}" target="_blank" rel="noopener">Download this image (right-click, save as)</a> and then <a href="https://backpack.openbadges.org/backpack/add" target="_blank" rel="noopener external">upload</a> it to your backpack.</li>
         </ol>
         <div class="image-container">
             <img class="badges-backpack-example" src="${static.url('certificates/images/backpack-ui.png')}">

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -69,9 +69,9 @@ from django.utils.http import urlquote_plus
                             </div>
                             <div class="msg-actions">
                                 %if certificate_data.cert_web_view_url:
-                                <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank" rel="noopener">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
                                 %elif certificate_data.cert_status == CertificateStatuses.downloadable and certificate_data.download_url:
-                                <a class="btn" href="${certificate_data.download_url}" target="_blank">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                <a class="btn" href="${certificate_data.download_url}" target="_blank" rel="noopener">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
                                 %elif certificate_data.cert_status == CertificateStatuses.requesting:
                                 <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
                                 %endif

--- a/lms/templates/credit_notifications/credit_eligibility_email.html
+++ b/lms/templates/credit_notifications/credit_eligibility_email.html
@@ -15,7 +15,7 @@
       <table>
         <tr>
           <td class="cn-img-wrapper">
-            <a target="_blank" title="" href="#">
+            <a target="_blank" rel="noopener" title="" href="#">
               <img class="cn-img" src="cid:${branded_logo}">
             </a>
           </td>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -196,7 +196,7 @@ from openedx.core.djangolib.markup import HTML, Text
               <li class="order-history">
                 <span class="title">${_("Order History")}</span>
                 % for order_history_item in order_history_list:
-                  <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+                  <span><a href="${order_history_item['receipt_url']}" target="_blank" rel="noopener" class="edit-name">${order_history_item['order_date']}</a></span>
                 % endfor
               </li>
               % endif

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -65,7 +65,7 @@ else:
             ${_("Your {cert_name_short} is Generating").format(cert_name_short=cert_name_short)}</span></li>
       % elif cert_status['show_download_url'] and cert_status.get('show_cert_web_view', False):
         <li class="action action-certificate">
-        <a class="btn" href="${cert_status['cert_web_view_url']}" target="_blank"
+        <a class="btn" href="${cert_status['cert_web_view_url']}" target="_blank" rel="noopener"
            title="${_('This link will open the certificate web view')}">
            ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}</a></li>
       % elif cert_status['show_download_url'] and enrollment.mode in CourseMode.NON_VERIFIED_MODES:
@@ -95,7 +95,7 @@ else:
   % if cert_status['show_download_url'] and cert_status['linked_in_url']:
   <ul class="actions actions-secondary">
       <li class="action action-share">
-        <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
+        <a class="action-linkedin-profile" target="_blank" rel="noopener" href="${cert_status['linked_in_url']}"
          title="${_('Add Certificate to LinkedIn Profile')}"
          data-course-id="${course_overview.id}"
          data-certificate-mode="${cert_status['mode']}"

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -177,9 +177,10 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                           aria-expanded="false"
                           href="${facebook_url}"
                           target="_blank"
+                          rel="noopener external"
                           title="${_('Share on Facebook')}"
                           data-course-id="${course_overview.id}"
-                          onclick="window.open('${facebook_url}', '${share_window_name}', '${share_window_config}'); return false;">
+                          onclick="var popupWindow = window.open('${facebook_url}', '${share_window_name}', '${share_window_config}'); popupWindow.opener = null; return false;">
                           <span class="sr">${_('Facebook')}</span>
                           <span class="fa fa-facebook" aria-hidden="true"></span>
                         </a>
@@ -198,9 +199,10 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                           aria-expanded="false"
                           href="${twitter_url}"
                           target="_blank"
+                          rel="noopener external"
                           title="${_('Share on Twitter')}"
                           data-course-id="${course_overview.id}"
-                          onclick="window.open('${twitter_url}', '${share_window_name}', '${share_window_config}'); return false;">
+                          onclick="var popupWindow = window.open('${twitter_url}', '${share_window_name}', '${share_window_config}'); popupWindow.opener = null; return false;">
                           <span class="sr">${_('Twitter')}</span>
                           <span class="fa fa-twitter" aria-hidden="true"></span>
                         </a>

--- a/lms/templates/dashboard/_dashboard_credit_info.html
+++ b/lms/templates/dashboard/_dashboard_credit_info.html
@@ -7,7 +7,7 @@
 
 % if credit_status["eligible"]:
     <%
-        provider_link = '<a href="{href}" target="_blank">{name}</a>'.format(
+        provider_link = '<a href="{href}" target="_blank" rel="noopener">{name}</a>'.format(
             href=credit_status["provider_status_url"],
             name=credit_status["provider_name"])
 
@@ -78,7 +78,7 @@
         </p>
         <div class="credit-action">
             % if credit_btn_label:
-                <a class="btn credit-btn ${credit_btn_class}" href="${credit_btn_href | h}" target="_blank" data-course-key="${credit_status['course_key'] | h}" data-user="${user.username | h}" data-provider="${credit_status['provider_id'] | h}">
+                <a class="btn credit-btn ${credit_btn_class}" href="${credit_btn_href | h}" target="_blank" rel="noopener" data-course-key="${credit_status['course_key'] | h}" data-user="${user.username | h}" data-provider="${credit_status['provider_id'] | h}">
                     ${credit_btn_label}
                 </a>
             % endif

--- a/lms/templates/fields/field_order_history.underscore
+++ b/lms/templates/fields/field_order_history.underscore
@@ -4,7 +4,7 @@
     <span class="u-field-order-price"><span class="sr"><%- gettext('Cost') %>: </span><% if (!isNaN(parseFloat(totalPrice))) { %>$<% } %><%- totalPrice %></span>
     <span class="u-field-order-link">
         <% if (receiptUrl) { %>
-            <a class="u-field-link" target="_blank" href="<%- receiptUrl %>"><%- gettext('Order Details') %><span class="sr"> <%- gettext('for') %> <%- orderId %></span></a>
+            <a class="u-field-link" target="_blank" rel="noopener" href="<%- receiptUrl %>"><%- gettext('Order Details') %><span class="sr"> <%- gettext('for') %> <%- orderId %></span></a>
         <% } %>
     </span>
     <% _.each(lines, function(item){ %>

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -48,7 +48,7 @@ from xmodule.tabs import CourseTabList
         <p>${Text(_('For {strong_start}questions on course lectures, homework, tools, or materials for this course{strong_end}, post in the {link_start}course discussion forum{link_end}.')).format(
           strong_start=HTML('<strong>'),
           strong_end=HTML('</strong>'),
-          link_start=HTML('<a href="{url}" target="_blank">').format(
+          link_start=HTML('<a href="{url}" target="_blank" rel="noopener">').format(
             url=discussion_link
           ),
           link_end=HTML('</a>'),
@@ -59,7 +59,7 @@ from xmodule.tabs import CourseTabList
         <p>${Text(_('Have {strong_start}general questions about {platform_name}{strong_end}? You can find lots of helpful information in the {platform_name} {link_start}FAQ{link_end}.')).format(
             strong_start=HTML('<strong>'),
             strong_end=HTML('</strong>'),
-            link_start=HTML('<a href="{url}" id="feedback-faq-link" target="_blank">').format(
+            link_start=HTML('<a href="{url}" id="feedback-faq-link" target="_blank" rel="noopener">').format(
               url=marketing_link('FAQ')
             ),
             link_end=HTML('</a>'),
@@ -134,7 +134,7 @@ from xmodule.tabs import CourseTabList
             'review our {link_start}detailed FAQs{link_end} where most questions have '
             'already been answered.'
         )).format(
-            link_start=HTML('<a href="{}" target="_blank" id="success-feedback-faq-link">').format(marketing_link('FAQ')),
+            link_start=HTML('<a href="{}" target="_blank" rel="noopener" id="success-feedback-faq-link">').format(marketing_link('FAQ')),
             link_end=HTML('</a>')
         )}
         </p>
@@ -344,7 +344,7 @@ $(document).ready(function() {
                 mailto = "mailto:" + "${settings.FEEDBACK_SUBMISSION_EMAIL | n, js_escaped_string}" +
                     "?subject=" + $("#feedback_form input[name='subject']").val() +
                     "&body=" + $("#feedback_form textarea[name='details']").val();
-                window.open(mailto);
+                window.open(mailto, '', 'noopener');
                 e.preventDefault();
             });
 %endif

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
@@ -12,10 +12,10 @@
     <div class="setup-value">
         <% if (cohort.get('assignment_type') == "manual") { %>
             <%- gettext("Learners are added to this cohort only when you provide their email addresses or usernames on this page.") %>
-            <a href="/help_token/cohortmanual" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="/help_token/cohortmanual" class="incontext-help action-secondary action-help" target="_blank" rel="noopener"><%- gettext("What does this mean?") %></a>
         <% } else { %>
             <%- gettext("Learners are added to this cohort automatically.") %>
-            <a href="/help_token/cohortautomatic" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="/help_token/cohortautomatic" class="incontext-help action-secondary action-help" target="_blank" rel="noopener"><%- gettext("What does this mean?") %></a>
         <% } %>
     </div>
 </div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
@@ -11,7 +11,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <p>
         <em>
             ${Text(_("For analytics about your course, go to {link_start}{analytics_dashboard_name}{link_end}.")).format(
-                link_start=HTML('<a href="{dashboard_url}" target="_blank">').format(
+                link_start=HTML('<a href="{dashboard_url}" target="_blank" rel="noopener">').format(
                     dashboard_url=escape_uri_path('{base_url}/courses/{course_id}'.format(
                         base_url=settings.ANALYTICS_DASHBOARD_URL,
                         course_id=section_data['course_id'],

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -27,7 +27,7 @@ from third_party_auth import provider, pipeline
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-        window.open( $(this).attr('href') );
+        window.open( $(this).attr('href'), '', 'noopener' );
         return false;
       });
 

--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
             % if description:
                 <div class="lti-description">${description}</div>
             % endif
-            <p class="lti-link external"><a target="_blank" class="link_lti_new_window" href="${form_url}">
+            <p class="lti-link external"><a target="_blank" rel="noopener" class="link_lti_new_window" href="${form_url}">
                 ${button_text or _('View resource in a new window')}
                  <span class="icon fa fa-external-link" aria-hidden="true"></span>
             </a></p>

--- a/lms/templates/modal/_modal-settings-language.html
+++ b/lms/templates/modal/_modal-settings-language.html
@@ -54,7 +54,7 @@ from django.core.urlresolvers import reverse
       <ul class="list list-actions actions-supplemental">
         <li class="list-actions-item">
         ${_("Don't see your preferred language? {link_start}Volunteer to become a translator!{link_end}").format(
-          link_start='<a class=" action action-volunteer" rel="external" target="_blank" href={translators_guide}>'.format(
+          link_start='<a class=" action action-volunteer" rel="external" target="_blank" rel="noopener" href={translators_guide}>'.format(
             translators_guide=settings.TRANSLATORS_GUIDE
           ),
           link_end="</a>"

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -63,7 +63,7 @@ from django.utils.translation import ugettext as _
 
     <li class="nav-item mt-2 nav-item-open-collapsed">
       <a href="${get_online_help_info(online_help_token)['doc_url']}"
-       target="_blank"
+       target="_blank" rel="noopener"
        class="nav-link">${_("Help")}</a>
     </li>
 

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -40,7 +40,7 @@ from django.utils.translation import ugettext as _
 <%include file="../user_dropdown.html"/>
 
 <a href="${get_online_help_info(online_help_token)['doc_url']}"
-         target="_blank"
+         target="_blank" rel="noopener"
          class="doc-link">${_("Help")}</a>
 
 % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -108,8 +108,8 @@ site_status_msg = get_site_status_msg(course_id)
 <div class="ie-banner" aria-hidden="true">${Text(_('{begin_strong}Warning:{end_strong} Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(
     begin_strong=HTML('<strong>'),
     end_strong=HTML('</strong>'),
-    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank">Chrome</a>'),
-    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank">Firefox</a>'),
+    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank" rel="noopener external">Chrome</a>'),
+    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank" rel="noopener external">Firefox</a>'),
 )}</div>
 <![endif]-->
 % endif

--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -25,7 +25,7 @@ import calendar
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -27,7 +27,7 @@ import calendar
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 

--- a/lms/templates/registration/account_activation_sidebar_notice.html
+++ b/lms/templates/registration/account_activation_sidebar_notice.html
@@ -23,7 +23,7 @@ from openedx.core.djangolib.markup import HTML, Text
           email_start=HTML("<strong>"),
           email_end=HTML("</strong>"),
           email=email,
-          link_start=HTML("<a target='_blank' href='{activation_email_support_link}'>").format(
+          link_start=HTML("<a target='_blank' rel='noopener' href='{activation_email_support_link}'>").format(
             activation_email_support_link=activation_email_support_link,
           ),
           link_end=HTML("</a>"),

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -128,7 +128,7 @@ import calendar
           <label data-field="terms_of_service" class="terms-of-service" for="signup_tos">
             <input id="signup_tos" name="terms_of_service" type="checkbox" value="true">
             ${_('I agree to the {link_start}Terms of Service{link_end}').format(
-              link_start='<a href="{url}" target="_blank">'.format(url=reverse('tos')),
+              link_start='<a href="{url}" target="_blank" rel="noopener">'.format(url=reverse('tos')),
               link_end='</a>') + ' *'}
           </label>
 
@@ -136,7 +136,7 @@ import calendar
           <label data-field="honor_code" class="honor-code" for="signup_honor">
             <input id="signup_honor" name="honor_code" type="checkbox" value="true">
             ${_('I agree to the {link_start}Honor Code{link_end}').format(
-              link_start='<a href="{url}" target="_blank">'.format(url=reverse('honor')),
+              link_start='<a href="{url}" target="_blank" rel="noopener">'.format(url=reverse('honor')),
               link_end='</a>') + ' *'}
           </label>
           % endif

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -7,7 +7,7 @@
         </label>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
-                <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                <a href="<%- supplementalLink %>" target="_blank" rel="noopener"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } %>
@@ -32,7 +32,7 @@
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
-                <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                <a href="<%- supplementalLink %>" target="_blank" rel="noopener"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } else if ( type === 'textarea' ) { %>
@@ -54,14 +54,14 @@
             <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
             <% if (supplementalLink && supplementalText) { %>
                 <div class="supplemental-link">
-                    <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                    <a href="<%- supplementalLink %>" target="_blank" rel="noopener"><%- supplementalText %></a>
                 </div>
             <% } %>
     <% } else { %>
         <% if ( type === 'checkbox' ) { %>
             <% if (supplementalLink && supplementalText) { %>
                 <div class="supplemental-link">
-                    <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                    <a href="<%- supplementalLink %>" target="_blank" rel="noopener"><%- supplementalText %></a>
                 </div>
             <% } %>
         <% } %>

--- a/lms/templates/student_profile/share_modal.underscore
+++ b/lms/templates/student_profile/share_modal.underscore
@@ -10,15 +10,15 @@
         <li class="step"><%=
         interpolate(
           gettext("Create a %(link_start)sMozilla Backpack%(link_end)s account, or log in to your existing account"),
-          {link_start: '<a href="https://backpack.openbadges.org/" target="_blank">', link_end: '</a>'},
+          {link_start: '<a href="https://backpack.openbadges.org/" target="_blank" rel="noopener external">', link_end: '</a>'},
           true
         )%>
         </li>
         <li class="step"><%=
         interpolate(
           gettext("%(download_link_start)sDownload this image (right-click or option-click, save as)%(link_end)s and then %(upload_link_start)supload%(link_end)s it to your backpack.</li>"), {
-            download_link_start: '<a class="badge-link" href="' + image_url + '" target="_blank">',
-            link_end: '</a>', upload_link_start: '<a href="https://backpack.openbadges.org/backpack/add" target="_blank">'
+            download_link_start: '<a class="badge-link" href="' + image_url + '" target="_blank" rel="noopener">',
+            link_end: '</a>', upload_link_start: '<a href="https://backpack.openbadges.org/backpack/add" target="_blank" rel="noopener external">'
           },
           true
         )%>

--- a/lms/templates/wiki/delete.html
+++ b/lms/templates/wiki/delete.html
@@ -26,7 +26,7 @@
 
       <ul>
         {% for child in delete_children %}
-        <li><a href="{% url 'wiki:get' article_id=child.article.id %}" target="_blank">{{ child.article }}</a></li>
+        <li><a href="{% url 'wiki:get' article_id=child.article.id %}" target="_blank" rel="noopener">{{ child.article }}</a></li>
         {% if delete_children_more %}
         <li><em>{% trans "...and more!" %}</em></li>
         {% endif %}

--- a/lms/templates/wiki/includes/cheatsheet.html
+++ b/lms/templates/wiki/includes/cheatsheet.html
@@ -13,9 +13,9 @@
           <h2>{% trans "Wiki Syntax Help" %}</h2>
           <p>{% trans "This wiki uses <strong>Markdown</strong> for styling. There are several useful guides online. See any of the links below for in-depth details:" %}</p>
           <ul>
-              <li><a href="http://daringfireball.net/projects/markdown/basics" target="_blank">{% trans 'Markdown: Basics' %}</a></li>
-              <li><a href="http://greg.vario.us/doc/markdown.txt" target="_blank">{% trans 'Quick Markdown Syntax Guide' %}</a></li>
-              <li><a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">{% trans 'Miniature Markdown Guide' %}</a></li>
+              <li><a href="http://daringfireball.net/projects/markdown/basics" target="_blank" rel="noopener external">{% trans 'Markdown: Basics' %}</a></li>
+              <li><a href="http://greg.vario.us/doc/markdown.txt" target="_blank" rel="noopener external">{% trans 'Quick Markdown Syntax Guide' %}</a></li>
+              <li><a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank" rel="noopener external">{% trans 'Miniature Markdown Guide' %}</a></li>
           </ul>
           <p>{% trans "To create a new wiki article, create a link to it. Clicking the link gives you the creation page." %}</p>
           <pre>{% trans "[Article Name](wiki:ArticleName)" %}</pre>

--- a/openedx/core/djangoapps/api_admin/widgets.py
+++ b/openedx/core/djangoapps/api_admin/widgets.py
@@ -26,7 +26,7 @@ class TermsOfServiceCheckboxInput(CheckboxInput):
         # platform_name is the name of this Open edX installation.
         label = _('I, and my company, accept the {link_start}{platform_name} API Terms of Service{link_end}.').format(
             platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-            link_start='<a href="{url}" target="_blank">'.format(url=reverse('api_admin:api-tos')),
+            link_start='<a href="{url}" target="_blank" rel="noopener">'.format(url=reverse('api_admin:api-tos')),
             link_end='</a>',
         )
 

--- a/openedx/core/lib/license/templates/license.html
+++ b/openedx/core/lib/license/templates/license.html
@@ -40,7 +40,7 @@ def parse_license(lic):
         enabled = ["zero"]
         version = license_options.get("ver", "1.0")
     %>
-    <a rel="license" href="https://creativecommons.org/licenses/${'-'.join(enabled)}/${version}/" target="_blank">
+    <a rel="license" href="https://creativecommons.org/licenses/${'-'.join(enabled)}/${version}/" target="_blank" rel="noopener">
     % if button:
         <img src="https://licensebuttons.net/l/${'-'.join(enabled)}/${version}/${button_size}.png"
              alt="${license}"

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -205,7 +205,7 @@ from openedx.core.djangoapps.theming import helpers as theming_helpers
           <li class="order-history">
             <span class="title">${_("Order History")}</span>
             % for order_history_item in order_history_list:
-              <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+              <span><a href="${order_history_item['receipt_url']}" target="_blank" rel="noopener" class="edit-name">${order_history_item['order_date']}</a></span>
             % endfor
           </li>
           % endif

--- a/themes/edx.org/lms/templates/header.html
+++ b/themes/edx.org/lms/templates/header.html
@@ -107,7 +107,7 @@ site_status_msg = get_site_status_msg(course_id)
       <%include file="user_dropdown.html"/>
 
       <a href="${get_online_help_info(online_help_token)['doc_url']}"
-         target="_blank"
+         target="_blank" rel="noopener"
          class="doc-link">${_("Help")}</a>
 
       % if should_display_shopping_cart_func(): # see shoppingcart.context_processor.user_has_cart_context_processor
@@ -154,8 +154,8 @@ site_status_msg = get_site_status_msg(course_id)
 <div class="ie-banner" aria-hidden="true">${Text(_('{begin_strong}Warning:{end_strong} Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(
     begin_strong=HTML('<strong>'),
     end_strong=HTML('</strong>'),
-    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank">Chrome</a>'),
-    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank">Firefox</a>'),
+    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank" rel="noopener external">Chrome</a>'),
+    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank" rel="noopener external">Firefox</a>'),
 )}</div>
 <![endif]-->
 % endif

--- a/themes/red-theme/lms/templates/header.html
+++ b/themes/red-theme/lms/templates/header.html
@@ -164,7 +164,7 @@ site_status_msg = get_site_status_msg(course_id)
 </header>
 % if course:
 <!--[if lte IE 8]>
-<div class="ie-banner" aria-hidden="true">${_(HTML('<strong>Warning:</strong> Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(chrome_link='<a href="https://www.google.com/intl/en/chrome/browser/" target="_blank">Chrome</a>', ff_link='<a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank">Firefox</a>')}</div>
+<div class="ie-banner" aria-hidden="true">${_(HTML('<strong>Warning:</strong> Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(chrome_link='<a href="https://www.google.com/intl/en/chrome/browser/" target="_blank" rel="noopener external">Chrome</a>', ff_link='<a href="http://www.mozilla.org/en-US/firefox/new/" target="_blank" rel="noopener external">Firefox</a>')}</div>
 <![endif]-->
 % endif
 

--- a/themes/stanford-style/lms/templates/register-shib.html
+++ b/themes/stanford-style/lms/templates/register-shib.html
@@ -19,7 +19,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 


### PR DESCRIPTION
Backports reverse tab-nabbing exploit, cf https://github.com/edx/edx-platform/pull/21635

**JIRA issue**

[SE-1740](https://tasks.opencraft.com/browse/SE-1740)

**Testing instructions**

This change will be deployed to [stage.campus.gov.il](https://stage.campus.gov.il) on Friday AM for testing.

1. Run through our [manual instance checklist](https://gitlab.com/opencraft/documentation/private/blob/master/checklists/manual_instance_test.md) to ensure that pages display ok, and that links and tabs work as expected.

**Author Notes & Concerns**

1. Let me know if you need me to grant your new account staff privileges so you can create courses.
1. [stage.campus.gov.il](https://stage.campus.gov.il) points to a WordPress marketing frontend, which has some broken links to courses which don't exist on stage, and can exhibit other issues.
   The LMS is hosted at [courses.stage.campus.gov.il](https://courses.stage.campus.gov.il), but there are redirects in place which can take you back to the marketing frontend.
   To complete testing, you may have to manually enter direct links to pages in the LMS, like the student dashboard: [courses.stage.campus.gov.il/dashboard](https://courses.stage.campus.gov.il/dashboard).

**Reviewer**

- [ ] @toxinu 