### PR TITLE
SE-1654 fix social login set cookies

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -655,6 +655,11 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
                     # the user log in successfully than that the cookie is set.
                     pass
                 else:
+                    # User object is not likely to be present in the request
+                    # this early in the login pipeline, so let's overwrite it
+                    # with the user we currently have in the pipeline.
+                    if user is not None:
+                        request.user = user
                     response = redirect(redirect_url)
                     return student.cookies.set_logged_in_cookies(request, response, user)
 


### PR DESCRIPTION
Currently there is an issue where logging in via google/facebook doesn't set the username in the user info cookie. This is subsequently re-set correctly when visiting the dashboard, but this doesn't happen of course when being redirected to a different page on login (eg. the marketing site).

This is a work in progress (untested) attempt to ensure a legit user object is used in the social login pipeline. It's apparently not guaranteed that the user object be correctly set in the request during this pipeline.

**Test instructions**:

- login with a social login, ensuring that the redirect url is to the marketing site (otherwise the default dashboard landing page will re-set the user info cookie)
- view the user-info cookie and verify that "username" is correctly set.

**Reviewer**:

- [ ] @pomegranited  