### PR TITLE
CAM2-325 Ensure format strings for student models allow unicode usernames

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1021,7 +1021,7 @@ class CourseEnrollment(models.Model):
 
     def __unicode__(self):
         return (
-            "[CourseEnrollment] {}: {} ({}); active: ({})"
+            u"[CourseEnrollment] {}: {} ({}); active: ({})"
         ).format(self.user, self.course_id, self.created, self.is_active)
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
@@ -1828,7 +1828,7 @@ class CourseEnrollmentAllowed(models.Model):
         unique_together = (('email', 'course_id'),)
 
     def __unicode__(self):
-        return "[CourseEnrollmentAllowed] %s: %s (%s)" % (self.email, self.course_id, self.created)
+        return u"[CourseEnrollmentAllowed] %s: %s (%s)" % (self.email, self.course_id, self.created)
 
     @classmethod
     def may_enroll_and_unenrolled(cls, course_id):
@@ -1889,7 +1889,7 @@ class CourseAccessRole(models.Model):
         return self._key < other._key  # pylint: disable=protected-access
 
     def __unicode__(self):
-        return "[CourseAccessRole] user: {}   role: {}   org: {}   course: {}".format(self.user.username, self.role, self.org, self.course_id)
+        return u"[CourseAccessRole] user: {}   role: {}   org: {}   course: {}".format(self.user.username, self.role, self.org, self.course_id)
 
 
 #### Helper methods for use from python manage.py shell and other classes.
@@ -2214,7 +2214,7 @@ class EntranceExamConfiguration(models.Model):
         unique_together = (('user', 'course_id'), )
 
     def __unicode__(self):
-        return "[EntranceExamConfiguration] %s: %s (%s) = %s" % (
+        return u"[EntranceExamConfiguration] %s: %s (%s) = %s" % (
             self.user, self.course_id, self.created, self.skip_entrance_exam
         )
 


### PR DESCRIPTION
Fixes issue where users with a Hebrew (unicode) username cannot be deleted from Django Admin. The issue is not an issue with the deletion itself, it's caused by Django's attempts to render the related models that will be deleted on the the Delete User confirmation screen.  The "render to unicode" string methods on these models must use unicode format strings.

**Testing instructions**

Deployed to courses.stage.campus.gov.il

1. Create a user with a Hebrew username, e.g. [this user](https://courses.stage.campus.gov.il/admin/auth/user/50/) (<-- ok to delete).
1. Enrol in a course ([user above has 5 enrollments](https://courses.stage.campus.gov.il/admin/student/courseenrollment/?q=%D7%92%D7%9E%D7%90%D7%9C_%D7%97%D7%98%D7%99%D7%91_1))
1. As a superuser in Django Admin, delete the user created in step 1.

**Author Notes & Concerns**

1. This PR only fixes the `student.model` unicode rendering, which is the most common type of associated record for users.  With the production users, there may be more models that need to be fixed.

**Reviewer**

- [ ] @pkulkark 