### PR TITLE
SE-2451 Ensure courseware models allow unicode rendering

### DIFF
--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -209,7 +209,14 @@ class StudentModuleHistory(BaseStudentModuleHistory):
     student_module = models.ForeignKey(StudentModule, db_index=True)
 
     def __unicode__(self):
-        return unicode(repr(self))
+        return u'{}<{!r}'.format(
+            self.__class__.__name__,
+            {
+                key: unicode(getattr(self, key))
+                for key in self._meta.get_all_field_names()
+                if key not in ('created', 'modified')
+            }
+        )
 
     def save_history(sender, instance, **kwargs):  # pylint: disable=no-self-argument, unused-argument
         """
@@ -256,7 +263,7 @@ class XBlockFieldBase(models.Model):
         return u'{}<{!r}'.format(
             self.__class__.__name__,
             {
-                key: getattr(self, key)
+                key: unicode(getattr(self, key))
                 for key in self._meta.get_all_field_names()
                 if key not in ('created', 'modified')
             }
@@ -317,7 +324,7 @@ class OfflineComputedGrade(models.Model):
         unique_together = (('user', 'course_id'), )
 
     def __unicode__(self):
-        return "[OfflineComputedGrade] %s: %s (%s) = %s" % (self.user, self.course_id, self.created, self.gradeset)
+        return u"[OfflineComputedGrade] %s: %s (%s) = %s" % (self.user, self.course_id, self.created, self.gradeset)
 
 
 class OfflineComputedGradeLog(models.Model):


### PR DESCRIPTION
Follow-up PR for https://github.com/edx-olive/edx-platform/pull/20

Fixes similar issues with courseware models.

**Testing instructions**

Deploying to courses.campus.gov.il

1. Create a user with a Hebrew username, e.g. [this user](https://courses.campus.gov.il/admin/auth/user/119837/) (<-- ok to delete).
1. From the shell, ensure the user has a related `courseware.models.XModuleStudentPrefsField` record (user above already does)
   ```python
   from courseware.models import XModuleStudentPrefsField
   from django.contrib.auth import get_user_model
   jamal = get_user_model().objects.get(username='גמאל_חטיב_1')
   XModuleStudentPrefsField.objects.create(student=jamal, value=u'"en"', module_type=u'video', field_name=u'transcript_langauge')
   ```
1. As a superuser in Django Admin, delete the user created in step 1.

**Author Notes & Concerns**

1. This PR only fixes the `courseware.model` unicode rendering, which is a common type of associated record for active users.  With the production users, there may be more models that need to be fixed.
1. Will need to be ported to Hawthorn/Ironwood, but will not be required in Juniper since python3 format strings support unicode by default. 

**Reviewer**

- [ ] @pkulkark 