### PR TITLE
[SE-2506][CAM2-328] Fix forum image upload

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1143,13 +1143,20 @@
             okButton = document.getElementById('new-link-image-ok');
             cancelButton = document.getElementById('new-link-image-cancel');
 
-            okButton.onclick = function() { return close(false); };
+            okButton.onclick = function() {
+                if (imageUploadHandler) {
+                    fileInput = document.getElementById('file-upload');
+                    imageUploadHandler(fileInput, urlInput);
+                }
+                setTimeout(() => { return close(false); }, 100);
+            };
+
             cancelButton.onclick = function() { return close(true); };
 
             if (imageUploadHandler) {
                 var startUploadHandler = function() {
                     document.getElementById('file-upload').onchange = function() {
-                        imageUploadHandler(this, urlInput);
+                        $(urlInput).attr('value', this.files.item(0).name);
                         urlInput.focus();
 
                         // Ensures that a user can update their file choice.

--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1148,7 +1148,7 @@
                     fileInput = document.getElementById('file-upload');
                     imageUploadHandler(fileInput, urlInput);
                 }
-                setTimeout(() => { return close(false); }, 100);
+                setTimeout(function() { return close(false); }, 1000);
             };
 
             cancelButton.onclick = function() { return close(true); };


### PR DESCRIPTION
This PR modifies the current forum image upload flow. The image was being uploaded to the configured storage when the user selected a file from the file picker without waiting for confirmation. The upload method will now be called only once the user clicks 'OK' button confirming the selection. 


**Testing Instructions:**
1. Go to a forum dicussion page in a course and click on 'Add a Post'.
2. In the editor, click on image icon and click 'Choose File' button to open file picker.
3. Select an image file you want to upload.
4. Verify the file name is shown in the text area. Provide a description for the image or enable flag indicating image is decorative only.
5. Click OK. Verify the upload api is called only after OK is clicked and the image is rendered in preview.


**Reviewers:**

- [x] @swalladge 


**Authors notes and concerns:**
1. The image will need to be uploaded before the entire post is submitted since the editor tries to generate the preview. So this still wouldn't handle the case where user uploads the image and then discards the post.
2. I couldn't find a better way other than introduce a wait time of 0.1sec after the user clicks 'OK' as we need to wait for the upload to complete before rendering the preview.