### PR TITLE
[SE-2507] Fixes bug when setting speed in video component

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -85,7 +85,7 @@
                     });
 
                     it('set current video speed via cookie', function() {
-                        expect(state.speed).toEqual('1.50');
+                        expect(state.speed).toEqual(1.5);
                     });
                 });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -188,7 +188,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });
@@ -207,7 +207,7 @@ function(Initialize) {
                     });
 
                     it('set new speed', function() {
-                        expect(state.speed).toEqual('0.75');
+                        expect(state.speed).toEqual(0.75);
                     });
                 });
 
@@ -217,7 +217,7 @@ function(Initialize) {
                     });
 
                     it('set speed to 1.0x', function() {
-                        expect(state.speed).toEqual('1.0');
+                        expect(state.speed).toEqual(1);
                     });
                 });
 
@@ -230,7 +230,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -54,7 +54,7 @@ function(VideoPlayer, HLS) {
 
                 it('create video caption', function() {
                     expect(state.videoCaption).toBeDefined();
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                     expect(state.config.transcriptTranslationUrl)
                         .toEqual('/transcript/translation/__lang__');
                 });
@@ -62,7 +62,7 @@ function(VideoPlayer, HLS) {
                 it('create video speed control', function() {
                     expect(state.videoSpeedControl).toBeDefined();
                     expect(state.videoSpeedControl.el).toHaveClass('speeds');
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                 });
 
                 it('create video progress slider', function() {

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -701,6 +701,7 @@ function(VideoPlayer, i18n, moment, _) {
             newSpeed = map[newSpeed];
             this.speed = _.contains(this.speeds, newSpeed) ? newSpeed : '1.0';
         }
+        this.speed = parseFloat(this.speed);
     }
 
     function getVideoMetadata(url, callback) {

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -231,21 +231,22 @@
          * not differs from current speed.
          */
         setSpeed: function(speed, silent, forceUpdate) {
-            if (speed !== this.currentSpeed || forceUpdate) {
+            var newSpeed = this.state.speedToString(speed);
+            if (newSpeed !== this.currentSpeed || forceUpdate) {
                 this.speedsContainer
                     .find('li')
-                    .siblings("li[data-speed='" + speed + "']");
+                    .siblings("li[data-speed='" + newSpeed + "']");
 
-                this.speedButton.find('.value').text(speed + 'x');
-                this.currentSpeed = speed;
+                this.speedButton.find('.value').text(newSpeed + 'x');
+                this.currentSpeed = newSpeed;
 
                 if (!silent) {
-                    this.el.trigger('speedchange', [speed, this.state.speed]);
+                    this.el.trigger('speedchange', [newSpeed, this.state.speed]);
                 }
             }
 
             this.resetActiveSpeed();
-            this.setActiveSpeed(speed);
+            this.setActiveSpeed(newSpeed);
         },
 
         resetActiveSpeed: function() {
@@ -259,13 +260,13 @@
         },
 
         setActiveSpeed: function(speed) {
-            var speedOption = this.speedsContainer.find('li[data-speed="' + speed + '"]');
+            var speedOption = this.speedsContainer.find('li[data-speed="' + this.state.speedToString(speed) + '"]');
 
             speedOption.addClass('is-active')
                 .find('.speed-option')
                 .attr('aria-pressed', 'true');
 
-            this.speedButton.attr('title', gettext('Video speed: ') + speed + 'x');
+            this.speedButton.attr('title', gettext('Video speed: ') + this.state.speedToString(speed) + 'x');
         },
 
         /**

--- a/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
+++ b/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
@@ -216,7 +216,8 @@ function(Component) {
         },
 
         appendContent: function(content) {
-            this.getElement().append(content);
+            var $content = $(content);
+            this.getElement().append($content);
             return this;
         },
 
@@ -246,8 +247,8 @@ function(Component) {
         },
 
         open: function() {
-            var menu = (this.isRendered) ? this.getElement() : this.populateElement();
-            this.container.append(menu);
+            var $menu = (this.isRendered) ? this.getElement() : this.populateElement();
+            this.container.append($menu);
             AbstractItem.prototype.open.call(this);
             this.overlay.show(this.container);
             return this;
@@ -354,7 +355,8 @@ function(Component) {
         },
 
         show: function(container) {
-            $(container).append(this.getElement());
+            var $elem = $(this.getElement());
+            $(container).append($elem);
             this.delegateEvents();
             return this;
         },
@@ -389,7 +391,9 @@ function(Component) {
         },
 
         createElement: function() {
-            var element = $('<li />', {
+            var $spanElem,
+                $listElem,
+                $element = $('<li />', {
                 'class': ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
                 'aria-expanded': 'false',
                 'aria-haspopup': 'true',
@@ -398,21 +402,25 @@ function(Component) {
                 'tabindex': -1
             });
 
-            this.label = $('<span />', {
-                'id': 'submenu-item-label-' + this.id,
-                'text': this.options.label
-            }).appendTo(element);
+            $spanElem = $('<span />', {
+                id: 'submenu-item-label-' + this.id,
+                text: this.options.label
+            });
+            this.label = $spanElem.appendTo($element);
 
-            this.list = $('<ol />', {
-                'class': ['submenu', this.options.prefix + 'submenu'].join(' '),
-                'role': 'menu'
-            }).appendTo(element);
+            $listElem = $('<ol />', {
+                class: ['submenu', this.options.prefix + 'submenu'].join(' '),
+                role: 'menu'
+            });
 
-            return element;
+            this.list = $listElem.appendTo($element);
+
+            return $element;
         },
 
         appendContent: function(content) {
-            this.list.append(content);
+            var $content = $(content);
+            this.list.append($content);
             return this;
         },
 
@@ -627,7 +635,7 @@ function(Component) {
                 }, {
                     label: i18n.Speed,
                     items: _.map(state.speeds, function(speed) {
-                        var isSelected = speed === state.speed;
+                        var isSelected = parseFloat(speed) === state.speed;
                         return {label: speed + 'x', callback: speedCallback, speed: speed, isSelected: isSelected};
                     }),
                     initialize: function(menuitem) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -100,8 +100,8 @@
             onSpeedChange: function(event, newSpeed, oldSpeed) {
                 this.log('speed_change_video', {
                     current_time: this.getCurrentTime(),
-                    old_speed: oldSpeed,
-                    new_speed: newSpeed
+                    old_speed: this.state.speedToString(oldSpeed),
+                    new_speed: this.state.speedToString(newSpeed)
                 });
             },
 


### PR DESCRIPTION
(cherry picked from commit a5fe668 - edx/edx-platform#19888)

First, there was a ["fix video player speed adjustments" pull request](https://github.com/edx/edx-platform/pull/19645) merged into the edx-platform. That commit was later on [cherry picked into the `edx-olive/edx-platform:master`](https://github.com/edx-olive/edx-platform/commit/f1237039ee5c82e3ac529e9fe803b621773e93ef).

However, the next month, another [pull request came up "patch video player speed adjustments"](https://github.com/edx/edx-platform/pull/19888). However, this commit was not cherry picked into the [`edx-olive/edx-platform:master`](https://github.com/edx-olive/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/video/01_initialize.js#L686-L705) or [`edx-olive/edx-platform:pooja/cherry-pick-pymongo-upgrade`](https://github.com/edx-olive/edx-platform/blob/pooja/cherry-pick-pymongo-upgrade/common/lib/xmodule/xmodule/js/src/video/01_initialize.js#L685-L704).

**JIRA tickets**: SE-2507, CAM2-329

**Testing instructions**:

1. Go to a course with video contents.
1. Locate a section where there are several videos spread across various units.
1. Go to a Youtube video. Ideally, if no video was visited before going to that video i.e. no video state, the video would be at 1.0x speed.
1. Change the speed and verify. Now, reload the same page.
1. Verify that speed will be the one that was set earlier. Playing it will launch the video with selected speed.
1. Now, from the same page, move onto another unit where there is a video. That video shouldn't have been visited before.
1. Verify that video's speed is same as the previous video. Play the video.
1. Verify that it will play with the selected speed.

**Reviewers**
- [ ] @pkulkark 
