### PR TITLE
[SE-3463] Revert part of last commit because the upload widget is broken

### DIFF
--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -1,7 +1,5 @@
-define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui-toolkit/js/utils/html-utils',
-    'jquery.form'],
-    function($, _, gettext, BaseModal, HtmlUtils) {
-        'use strict';
+define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery.form'],
+    function($, _, gettext, BaseModal) {
         var UploadDialog = BaseModal.extend({
             events: _.extend({}, BaseModal.prototype.events, {
                 'change input[type=file]': 'selectFile',
@@ -41,7 +39,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui
                 // a blank input to prompt the user to upload a different (valid) file.
                 if (selectedFile && isValid) {
                     $(oldInput).removeClass('error');
-                    this.$('input[type=file]').replaceWith(HtmlUtils.ensureHtml(oldInput).toString());
+                    this.$('input[type=file]').replaceWith(oldInput);
                     this.$('.action-upload').removeClass('disabled');
                 } else {
                     this.$('.action-upload').addClass('disabled');
@@ -52,7 +50,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui
             getContentHtml: function() {
                 return this.template({
                     url: this.options.url || CMS.URL.UPLOAD_ASSET,
-                    message: this.model.get('message'),
+                    message: this.model.escape('message'),
                     selectedFile: this.model.get('selectedFile'),
                     uploading: this.model.get('uploading'),
                     uploadedBytes: this.model.get('uploadedBytes'),


### PR DESCRIPTION
This is an urgent request, therefore I'll be merging now to fix production, and we can work on a better fix later.

The fix is to revert the part of the last PR, https://github.com/edx-olive/edx-platform/pull/32: the part that deals with file uploads.

I tested [in Studio](https://studio.stage.campus.gov.il/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@d94f702210e64a7aadcaab278631dda7?action=new) that I can now upload transcripts, whereas I couldn't before this patch (I was getting `[object HTMLInputElement]`, as Campus reported).

This old behaviour should be fine because it's what was before https://github.com/edx-olive/edx-platform/pull/32
We'll need to reapply the XSS patch.
