### PR TITLE
[SE-3511] [CAM-425] Fix handling of course keys in admin models.

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 import cms.lib.xblock.runtime
 import xmodule.x_module
-from openedx.core.djangoapps.monkey_patch import django_db_models_options
+from openedx.core.djangoapps.monkey_patch import django_db_models_options, django_contrib_admin_options
 from openedx.core.djangoapps.theming.core import enable_theming
 from openedx.core.djangoapps.theming.helpers import is_comprehensive_theming_enabled
 from openedx.core.lib.django_startup import autostartup
@@ -25,6 +25,7 @@ def run():
     Executed during django startup
     """
     django_db_models_options.patch()
+    django_contrib_admin_options.patch()
 
     # Comprehensive theming needs to be set up before django startup,
     # because modifying django template paths after startup has no effect.

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -15,7 +15,7 @@ from openedx.core.lib.django_startup import autostartup
 from openedx.core.release import doc_version
 import analytics
 
-from openedx.core.djangoapps.monkey_patch import django_db_models_options
+from openedx.core.djangoapps.monkey_patch import django_db_models_options, django_contrib_admin_options
 
 import xmodule.x_module
 import lms_xblock.runtime
@@ -34,6 +34,7 @@ def run():
     Executed during django startup
     """
     django_db_models_options.patch()
+    django_contrib_admin_options.patch()
 
     # To override the settings before executing the autostartup() for python-social-auth
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):

--- a/openedx/core/djangoapps/monkey_patch/django_contrib_admin_options.py
+++ b/openedx/core/djangoapps/monkey_patch/django_contrib_admin_options.py
@@ -1,0 +1,38 @@
+"""
+Monkey patch implementation of the quote and unquote functions used in admin:
+
+https://github.com/django/django/blob/de81676b51e4dad510ef387c3ae625f9091fe57f/django/contrib/admin/utils.py#L66
+
+Remove once we upgrade to Juniper, which uses a Django version with these changes.
+"""
+import re
+import struct
+from django.contrib.admin import options
+
+__QUOTE__NAME = 'quote__original'
+__UNQUOTE__NAME = 'unquote__original'
+
+
+QUOTE_MAP = {struct.unpack('b', c)[0]: '_%02X' % struct.unpack('b', c) for c in b'":/_#?;@&=+$,"[]<>%\n\\'}
+UNQUOTE_MAP = {v: chr(k) for k, v in QUOTE_MAP.items()}
+UNQUOTE_RE = re.compile('_(?:%s)' % '|'.join([x[1:] for x in UNQUOTE_MAP]))
+
+
+def quote(s):
+    """
+    Ensure that primary key values do not confuse the admin URLs by escaping
+    any '/', '_' and ':' and similarly problematic characters.
+    Similar to urllib.parse.quote(), except that the quoting is slightly
+    different so that it doesn't get automatically unquoted by the Web browser.
+    """
+    return s.translate(QUOTE_MAP) if isinstance(s, str) else s
+
+
+def unquote(s):
+    """Undo the effects of quote()."""
+    return UNQUOTE_RE.sub(lambda m: UNQUOTE_MAP[m[0]], s)
+
+
+def patch():
+    setattr(options, 'quote', quote)
+    setattr(options, 'unquote', unquote)

--- a/openedx/core/djangoapps/monkey_patch/tests/test_course_overview_options.py
+++ b/openedx/core/djangoapps/monkey_patch/tests/test_course_overview_options.py
@@ -1,0 +1,38 @@
+"""
+Tests for the monkey patch applied to admin options in order to make course overviews work in the admin.
+"""
+from ddt import ddt, data, unpack
+from nose.plugins.attrib import attr
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+@ddt
+@attr(shard=3)
+class CourseOverviewAdminTestCase(ModuleStoreTestCase):
+    @unpack
+    @data(
+        ("CS", "GOV_CS_selfpy101", "3_2020", "course-v1:CS+GOV_CS_selfpy101+3_2020"),
+        ("edX", "DemoX", "Demo_Course", "course-v1:edX+DemoX+Demo_Course"),
+    )
+    def test_course_overview_admin(self, org, number, run, url_key):
+        """
+        Test that course IDs that worked before should still work, and that course IDs that were broken should work
+        now as well.
+        """
+        course = CourseFactory.create(
+            default_store=ModuleStoreEnum.Type.split, org=org, number=number, run=run,
+        )
+        # Side effect: Creates a CourseOverview if it does not exist.
+        CourseOverview.get_from_id(course.id)
+        self.user.is_staff = True
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.login(username=self.user.username, password=self.user_password)
+        response = self.client.get('/admin/course_overviews/courseoverview/')
+        target_url = '/admin/course_overviews/courseoverview/{}/'.format(url_key)
+        self.assertIn(target_url, response.content)
+        response = self.client.get(target_url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR fixes an issue where attempting to visit Course Overviews in the admin that had course IDs with certain content would throw an error due to issues with the sanitation functions present.

This backports the new version of Django's handling of object ID sanitation which allows it to work with course keys, and monkey patches it in the relevent code.

**JIRA tickets**: https://tasks.opencraft.com/browse/SE-3511 https://lnet-jira.atlassian.net/browse/CAM2-425

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: Tuesday October 27, 2020

**Testing instructions**:

1. Check out this version on a campus devstack
2. Comment out the `setattr` lines in the patch.
3. Run `paver test_system -s cms -t openedx.core.djangoapps.monkey_patch.tests` and confirm the tests fail.
4. Uncomment the `setattr` lines and rerun the tests, confirming success.

**Author notes and concerns**:

This issue does not exist in Juniper. The commit message and comments have been written to make it clear that these should be rolled back when we upgrade.

This PR is set against the branch that is currently on production. Should it become the new production branch? Should we make a particular release branch instead of using the branch we're currently using?

**Reviewers**
- [ ] @pkulkark 