### PR TITLE
[SE-3463] Apply correction to the last XSS patch and a new XSS patch

### DIFF
--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -28,7 +28,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery
             renderContents: function() {
                 var isValid = this.model.isValid(),
                     selectedFile = this.model.get('selectedFile'),
-                    oldInput = this.$('input[type=file]').get(0);
+                    oldInput = this.$('input[type=file]');
                 BaseModal.prototype.renderContents.call(this);
                 // Ideally, we'd like to tell the browser to pre-populate the
                 // <input type="file"> with the selectedFile if we have one -- but
@@ -39,7 +39,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery
                 // a blank input to prompt the user to upload a different (valid) file.
                 if (selectedFile && isValid) {
                     $(oldInput).removeClass('error');
-                    this.$('input[type=file]').replaceWith(oldInput);
+                    this.$('input[type=file]').replaceWith(HtmlUtils.HTML(oldInput).toString());
                     this.$('.action-upload').removeClass('disabled');
                 } else {
                     this.$('.action-upload').addClass('disabled');

--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -1,5 +1,5 @@
-define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery.form'],
-    function($, _, gettext, BaseModal) {
+define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui-toolkit/js/utils/html-utils', 'jquery.form'],
+    function($, _, gettext, BaseModal, HtmlUtils) {
         var UploadDialog = BaseModal.extend({
             events: _.extend({}, BaseModal.prototype.events, {
                 'change input[type=file]': 'selectFile',
@@ -50,7 +50,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'jquery
             getContentHtml: function() {
                 return this.template({
                     url: this.options.url || CMS.URL.UPLOAD_ASSET,
-                    message: this.model.escape('message'),
+                    message: this.model.get('message'),
                     selectedFile: this.model.get('selectedFile'),
                     uploading: this.model.get('uploading'),
                     uploadedBytes: this.model.get('uploadedBytes'),

--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -31,9 +31,9 @@
 
     <% if(showGroups) { %>
       <% allocation = Math.floor(100 / groups.length) %>
-      <ol class="collection-items groups groups-<%= index %>">
+      <ol class="collection-items groups groups-<%- index %>">
         <% groups.each(function(group, groupIndex) { %>
-          <li class="item group group-<%= groupIndex %>">
+          <li class="item group group-<%- groupIndex %>">
             <span class="name group-name"><%- group.get('name') %></span>
             <span class="meta group-allocation"><%- allocation %>%</span>
           </li>

--- a/cms/templates/js/maintenance/force-published-course-response.underscore
+++ b/cms/templates/js/maintenance/force-published-course-response.underscore
@@ -3,7 +3,7 @@
         <%- gettext('You have done a dry run of force publishing the course. Nothing has changed. Had you run it, the following course versions would have been change.') %>
     </div>
     <div class="main-output">
-        <%= StringUtils.interpolate(
+        <%- StringUtils.interpolate(
             gettext('The published branch version, {published}, was reset to the draft branch version, {draft}.'),
             {
                 published: current_versions['published-branch'],

--- a/cms/templates/js/mock/mock-xmodule-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor.underscore
@@ -16,13 +16,13 @@
 
         <script id="metadata-string-entry" type="text/template">
             <div class="wrapper-comp-setting">
-                \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-                \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+                \t<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+                \t<input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
                 \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
                 <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"Clear Value"</span>
                 </button>
             </div>
-            <span class="tip setting-help"><%= model.get('help') %></span>
+            <span class="tip setting-help"><%- model.get('help') %></span>
 
         </script>
 

--- a/cms/templates/js/publish-editor.underscore
+++ b/cms/templates/js/publish-editor.underscore
@@ -6,13 +6,13 @@
             <% _.each(xblockInfo.get('child_info').children, function(subsection) { %>
               <% if (subsection.isPublishable())  { %>
                 <li class="outline-item outline-subsection">
-                    <h4 class="subsection-title item-title"><%= subsection.get('display_name') %></h4>
+                    <h4 class="subsection-title item-title"><%- subsection.get('display_name') %></h4>
                     <div class="subsection-content">
                         <ol class="list-units">
                           <% _.each(subsection.get('child_info').children, function(unit) { %>
                             <% if (unit.isPublishable())  { %>
                               <li class="outline-item outline-unit">
-                                  <span class="unit-title item-title"><%= unit.get('display_name') %></span>
+                                  <span class="unit-title item-title"><%- unit.get('display_name') %></span>
                               </li>
                             <% } %>
                           <% }); %>
@@ -27,7 +27,7 @@
             <% _.each(xblockInfo.get('child_info').children, function(unit) { %>
               <% if (unit.isPublishable())  { %>
                 <li class="outline-item outline-unit">
-                    <span class="unit-title item-title"><%= unit.get('display_name') %></span>
+                    <span class="unit-title item-title"><%- unit.get('display_name') %></span>
                 </li>
               <% } %>
             <% }); %>

--- a/cms/templates/js/unit-outline.underscore
+++ b/cms/templates/js/unit-outline.underscore
@@ -1,23 +1,23 @@
 <% if (parentInfo) { %>
-    <li class="outline-item outline-<%= xblockType %> <%= visibilityClass %> <%= xblockInfo.get('id') === currentUnitId ? 'is-current' : '' %>"
-        data-parent="<%= parentInfo.get('id') %>" data-locator="<%= xblockInfo.get('id') %>">
-        <div class="<%= xblockType %>-header">
-            <h3 class="<%= xblockType %>-header-details">
-                <span class="<%= xblockType %>-title item-title">
-                    <a href="<%= xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
+    <li class="outline-item outline-<%- xblockType %> <%- visibilityClass %> <%- xblockInfo.get('id') === currentUnitId ? 'is-current' : '' %>"
+        data-parent="<%- parentInfo.get('id') %>" data-locator="<%- xblockInfo.get('id') %>">
+        <div class="<%- xblockType %>-header">
+            <h3 class="<%- xblockType %>-header-details">
+                <span class="<%- xblockType %>-title item-title">
+                    <a href="<%- xblockInfo.get('studio_url') %>"><%- xblockInfo.get('display_name') %></a>
                 </span>
             </h3>
         </div>
 <% } %>
 
-        <div class="<%= xblockType %>-content outline-content">
-            <ol class="<%= typeListClass %>">
+        <div class="<%- xblockType %>-content outline-content">
+            <ol class="<%- typeListClass %>">
             </ol>
             <% if (childType) { %>
-                <div class="add-<%= childType %> add-item">
-                    <a href="#" class="button button-new" data-category="<%= childCategory %>"
-                       data-parent="<%= xblockInfo.get('id') %>" data-default-name="<%= defaultNewChildName %>">
-                        <span class="icon fa fa-plus" aria-hidden="true"></span><%= addChildLabel %>
+                <div class="add-<%- childType %> add-item">
+                    <a href="#" class="button button-new" data-category="<%- childCategory %>"
+                       data-parent="<%- xblockInfo.get('id') %>" data-default-name="<%- defaultNewChildName %>">
+                        <span class="icon fa fa-plus" aria-hidden="true"></span><%- addChildLabel %>
                     </a>
                 </div>
             <% } %>

--- a/cms/templates/js/video/transcripts/file-upload.underscore
+++ b/cms/templates/js/video/transcripts/file-upload.underscore
@@ -6,5 +6,5 @@
   <input type="file" class="file-input" name="transcript-file"
     accept="<%- _.map(ext, function(val){ return '.' + val; }).join(', ') %>">
   <input type="hidden" name="locator" value="<%- component_locator %>">
-  <input type="hidden" name="video_list" value='<%= JSON.stringify(video_list) %>'>
+  <input type="hidden" name="video_list" value='<%- JSON.stringify(video_list) %>'>
 </form>

--- a/cms/templates/js/video/transcripts/file-upload.underscore
+++ b/cms/templates/js/video/transcripts/file-upload.underscore
@@ -4,7 +4,7 @@
 <form class="file-chooser" action="/transcripts/upload"
                           method="post" enctype="multipart/form-data">
   <input type="file" class="file-input" name="transcript-file"
-    accept="<%= _.map(ext, function(val){ return '.' + val; }).join(', ') %>">
-  <input type="hidden" name="locator" value="<%= component_locator %>">
+    accept="<%- _.map(ext, function(val){ return '.' + val; }).join(', ') %>">
+  <input type="hidden" name="locator" value="<%- component_locator %>">
   <input type="hidden" name="video_list" value='<%= JSON.stringify(video_list) %>'>
 </form>

--- a/cms/templates/js/xblock-validation-messages.underscore
+++ b/cms/templates/js/xblock-validation-messages.underscore
@@ -3,7 +3,7 @@ var summaryMessage = validation.get("summary");
 var aggregateMessageType = summaryMessage.type;
 var aggregateValidationClass = aggregateMessageType === "error"? "has-errors" : "has-warnings";
 %>
-    <div class="xblock-message validation <%= aggregateValidationClass %> <%= additionalClasses %>">
+    <div class="xblock-message validation <%- aggregateValidationClass %> <%- additionalClasses %>">
         <p class="<%- aggregateMessageType %>"><span class="icon fa <%- getIcon(aggregateMessageType) %>" aria-hidden="true"></span>
         <%- summaryMessage.text %>
         <% if (summaryMessage.action_class) { %>
@@ -25,7 +25,7 @@ var aggregateValidationClass = aggregateMessageType === "error"? "has-errors" : 
                 var messageType = message.type
                 var messageTypeDisplayName = getDisplayName(messageType)
                 %>
-                <li class="xblock-message-item <%= messageType %>">
+                <li class="xblock-message-item <%- messageType %>">
                     <span class="message-text">
                         <% if (messageTypeDisplayName) { %>
                             <span class="sr"><%- messageTypeDisplayName %>:</span>


### PR DESCRIPTION
This combines several security patches, mainly from https://github.com/open-craft/edx-platform/pull/273/ but also https://github.com/open-craft/edx-platform/pull/272 and it also has a small original patch.
We backport all that to the current Campus branch.

## Fix the previous XSS patch that broke video uploads
We previously reverted part of a XSS patch: https://github.com/edx-olive/edx-platform/pull/35
The proper fix was done upstream: https://github.com/edx/edx-platform/commit/6a0cdf46fc8e0cd74accac9e8fb6109c2f4497e0
This PR cherry-picks that commit, so it should fix the XSS without breaking the uploads.

## More fixes
The rest of the fixes in this PR come from https://github.com/open-craft/edx-platform/pull/273/commits
I'll explain each one in the following sections.

## new XSS patches
„sustaining security fixes 6“ (XSS patch), https://github.com/edx/edx-platform/commit/e5d7128bee5ab6542b7542c122a73825eb3df5e5

This was applied cleanly. When I applied I found another line that would need this change (I guess) but that wasn't in the Juniper patch because it just exists in Ginkgo:
```
-  <input type="hidden" name="video_list" value='<%= JSON.stringify(video_list) %>'>
+  <input type="hidden" name="video_list" value='<%- JSON.stringify(video_list) %>'>
```
I did the change in this PR too.

## Password reset token leakage
https://github.com/open-craft/edx-platform/pull/273/commits/a83fa852944b116466770968b67e28ab24b666e2

I have trouble backporting https://github.com/edx/edx-platform/commit/4b3932769f085399385a246b106fef736349bda6 to Ginkgo. There are merge conflicts because `edx-platform/openedx/core/djangoapps/user_authn` doesn't exist in Ginkgo.
`PasswordResetConfirmWrapper` (the class used and modified by that patch) doesn't even exist in Ginkgo, and the equivalent code is implemented [by a function](https://github.com/edx-olive/edx-platform/blob/7d809dafae7890fb0b9a2b2052a9d7f373e5579a/common/djangoapps/student/views.py#L2547) with different code than the code seen in the patch.

Seeing that this issue doesn't affect Campus (see screenshots and description at SE-3412) I think we shouldn't backport it. We wouldn't notice any difference if we did. We should just be careful not to add external links to untrusted sites in the footer.

## Upgrade Django to 2.2.16
https://github.com/open-craft/edx-platform/pull/273/commits/7c6f286a2e6e1660f4ed9ee2f5f852218265057a

It doesn't make sense to apply the patch to upgrade to Django 2.2.15 to 2.2.16 since [we're using](https://github.com/edx-olive/edx-platform/blob/7d809dafae7890fb0b9a2b2052a9d7f373e5579a/requirements/edx/base.txt#L42): `django==1.8.18`

## jenkins-worker

https://github.com/open-craft/edx-platform/pull/273/commits/328411c21f6fd33aaecb2f2c1f0361815e179905

The patch about renaming `jenkins-worker` → `juniper-worker` obviously isn't desired since we're not on Juniper. But the modified code doesn't even exist in Ginkgo, so we have nothing to change. There's no `edx-platform/scripts/Jenkinsfiles` folder, nor references to `jenkins-worker`

## certificate URLs
https://github.com/open-craft/edx-platform/pull/273/commits/5ee006d80c470c91a1728f6ff453cccc8eef4325

There are all sorts of non-trivial merge conflicts when trying to apply the certificate URL patch, involving `six`, code to handle circular `imports`, tests and obviously the logic pass parameters in URLs.
I [copied them here](https://gist.github.com/clemente/624cade49b93a6f39545607814aaa575).
Therefore I think we can't backport this so easily and we'd need to do much more work.

For now, we'd have to stay with this issue until we upgrade.
The issue is not critical, it just shows the user ID as part of the certificate URL.
- e.g. current URL (without the patch): https://LMS/certificates/user/6/course/course-v1:edX+DemoX+Demo_Course?preview=honor
- e.g. new URL (if we had the patch): https://LMS/certificates/course-v1:edX+DemoX+Demo_Course

## How to test this
The main things to test are video transcript uploads (since it's what was broken by the XSS patches) and something affected by the XSS patch. We can trust that the edX XSS patch is mostly correct and test the video transcript uploads.

Test in Campus stage, and if it works deploy to production.

Campus stage is being used for other deployments, so we'll need to synchronize.