### PR TITLE
SE-3566 Match item_type for edx-sga submissions

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -204,12 +204,20 @@ def _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs):
 
     else:
         assert kwargs['score_db_table'] == ScoreDatabaseTableEnum.submissions
+
+        # Hack to work around this oddity in edx-sga: https://github.com/open-craft/edx-sga/blob/db7da3da6ea13e342b33b261099fe4ce252f563c/edx_sga/sga.py#L160
+        # See also https://discuss.openedx.org/t/problems-with-sga-grade-submission/2415
+        if scored_block_usage_key.block_type == "edx_sga":
+            item_type = "sga"
+        else:
+            item_type = scored_block_usage_key.block_type
+
         score = sub_api.get_score(
             {
                 "student_id": kwargs['anonymous_user_id'],
                 "course_id": unicode(scored_block_usage_key.course_key),
                 "item_id": unicode(scored_block_usage_key),
-                "item_type": scored_block_usage_key.block_type,
+                "item_type": item_type,
             }
         )
         found_modified_time = score['created_at'] if score is not None else None


### PR DESCRIPTION
Solution suggested at https://discuss.openedx.org/t/problems-with-sga-grade-submission/2415

**Test instructions**:

- ensure persistant grades is enabled
- add an edx-sga block to a course (also add "edx_sga" to advanced modules list)
- set up grading so that the sga block contributes to the final grade, and so does at least one other problem block
- sign up to the course as a student
- complete the problem block
- do whatever required to submit something for the edx-sga block
- as the course instructor, grade the submission on the edx-sga block (navigate to the block in the course view, look for the Grade Submissions button)
- switch back to the student and view the progress page
- verify that the barchart and breakdown correctly show the score (this is important! the individual problem scores in the list/table view below the chart show the individual db grades, the subsection and progress chart use the persisted grades)
- change the grade on the edx-sga block as the instructor
- switch back to the student and view the progress page
- verify that the barchart and breakdown correctly show the updated score

**Reviewers**:

- [ ] @pkulkark 