### PR TITLE
[SE-3949] Fix RTL scrolling in grade books

### DIFF
--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -126,8 +126,6 @@ div.gradebook-wrapper {
 	}
 
 	.grade-table {
-		top: 0;
-		left: 0;
 		width: 1000px;
 		cursor: move;
 		@include transition(none);

--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -126,7 +126,6 @@ div.gradebook-wrapper {
 	}
 
 	.grade-table {
-		position: absolute;
 		top: 0;
 		left: 0;
 		width: 1000px;


### PR DESCRIPTION
This PR fixes RTL scrolling in grade books by removing the absolute positioning of `grade-table` which prevents scrolling if the direction is not LTR.

**Dependencies**: None

**Screenshots**: 

https://user-images.githubusercontent.com/19173947/104882909-222e6680-5964-11eb-9495-8f7090d8ce0b.mov

**Merge deadline**: ASAP

**Testing instructions**:

1. Open the grade book, referenced in the ticket
2. Find the HTML element with `grade-table` class
3. Remove/turn off the rules removed in this PR
4. Check the site in English
5. Change language to Hebrew and/or Arabic
6. Try again the changes
7. Validate the scrollbar changed

**Author notes and concerns**:

It is normal and expected if the scrollbar jumps to the right within the grade book after the rules are removed and the language is RTL.

**Reviewers**
- [ ] @pkulkark 