### PR TITLE
[SE-4175] Add CCX ID to generated filenames

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -251,6 +251,17 @@ FEATURES = {
 
     # Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,
+
+    # .. toggle_name: FEATURES['ENABLE_COURSE_FILENAME_CCX_SUFFIX']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If set to True, CCX ID will be included in the generated filename for CCX courses.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-03-16
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: None
+    # .. toggle_warnings: Turning this feature ON will affect all generated filenames which are related to CCX courses.
+    'ENABLE_COURSE_FILENAME_CCX_SUFFIX': False
 }
 
 ENABLE_JASMINE = False

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -111,10 +111,7 @@ def course_filename_prefix_generator(course_id, separator='_'):
     )
 
     if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):
-        filename += '{separator}ccx{separator}{ccx_id}'.format(
-            separator=separator,
-            ccx_id=course_id.ccx
-        )
+        filename += separator.join([filename, 'ccx', course_id.ccx])
 
     return get_valid_filename(filename)
 

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -111,7 +111,7 @@ def course_filename_prefix_generator(course_id, separator='_'):
     )
 
     if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):
-        filename += separator.join([filename, 'ccx', course_id.ccx])
+        filename = separator.join([filename, 'ccx', course_id.ccx])
 
     return get_valid_filename(filename)
 

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -12,8 +12,6 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from pytz import UTC
 
-from lms.djangoapps.ccx.utils import get_ccx_from_ccx_locator
-
 
 class FileValidationException(Exception):
     """
@@ -113,10 +111,9 @@ def course_filename_prefix_generator(course_id, separator='_'):
     )
 
     if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):
-        ccx = get_ccx_from_ccx_locator(course_id)
         filename += '{separator}ccx{separator}{ccx_id}'.format(
             separator=separator,
-            ccx_id=ccx.id
+            ccx_id=course_id.ccx
         )
 
     return get_valid_filename(filename)

--- a/common/djangoapps/util/file.py
+++ b/common/djangoapps/util/file.py
@@ -5,11 +5,14 @@ Utility methods related to file handling.
 import os
 from datetime import datetime
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import DefaultStorage, get_valid_filename
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from pytz import UTC
+
+from lms.djangoapps.ccx.utils import get_ccx_from_ccx_locator
 
 
 class FileValidationException(Exception):
@@ -89,16 +92,34 @@ def store_uploaded_file(
 # pylint: disable=invalid-name
 def course_filename_prefix_generator(course_id, separator='_'):
     """
-    Generates a course-identifying unicode string for use in a file
-    name.
+    Generates a course-identifying unicode string for use in a file name.
 
     Args:
         course_id (object): A course identification object.
+        separator (str): The character or chain of characters used for separating course details in
+            the filename.
     Returns:
-        str: A unicode string which can safely be inserted into a
-            filename.
+        str: A unicode string which can safely be inserted into a filename.
     """
-    return get_valid_filename(unicode(separator).join([course_id.org, course_id.course, course_id.run]))
+    filename = unicode(separator).join([
+        course_id.org,
+        course_id.course,
+        course_id.run
+    ])
+
+    enable_course_filename_ccx_suffix = settings.FEATURES.get(
+        'ENABLE_COURSE_FILENAME_CCX_SUFFIX',
+        False
+    )
+
+    if enable_course_filename_ccx_suffix and getattr(course_id, 'ccx', None):
+        ccx = get_ccx_from_ccx_locator(course_id)
+        filename += '{separator}ccx{separator}{ccx_id}'.format(
+            separator=separator,
+            ccx_id=ccx.id
+        )
+
+    return get_valid_filename(filename)
 
 
 # pylint: disable=invalid-name

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -203,7 +203,7 @@ edx-django-release-util==0.3.0
 
 # Used to communicate with Neo4j, which is used internally for
 # modulestore inspection
-py2neo==3.1.2
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 
 # for calculating coverage
 -r coverage.txt


### PR DESCRIPTION
This pull requests adds a new feature to include CCX course IDs in the generated course filenames used for downloading reports, etc.

The suffix appended to the generated filename prefix is following the  `<separator>_ccx_<ccx id>` pattern, to ensure unique filename generation per ccx - previously all CCX courses were downloaded with the same name.

**Dependencies**: None

**Screenshots**: 
![Screenshot 2021-03-16 at 16 22 12](https://user-images.githubusercontent.com/19173947/111349994-f1c42980-8681-11eb-8fff-d28024899957.png)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Enable `ENABLE_GRADE_DOWNLOADS`, and `ENABLE_COURSE_FILENAME_CCX_SUFFIX` features.
2. Create a course
3. Enable CCX for the course in the advanced settings
4. Create a new CCX for the course
5. Generate and download grades

**Author notes and concerns**:

This PR differs from the upstream PR, since the upstream already removed Python2 related syntax from its code.

**Reviewers**
- [ ] @mavidser 