### PR TITLE
fix: ensure py2neo is installed

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -203,7 +203,7 @@ edx-django-release-util==0.3.0
 
 # Used to communicate with Neo4j, which is used internally for
 # modulestore inspection
-py2neo==3.1.2
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 
 # for calculating coverage
 -r coverage.txt


### PR DESCRIPTION
The version of Py2neo we depend on has been removed from PyPI.  This is
a stop-gap until we can upgrade it