### PR TITLE
[SE-4333] Update django-ses to a version which supports Signature Version 4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -30,7 +30,7 @@ django-oauth-toolkit==0.10.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.6
 django-sekizai==0.8.2
-django-ses==1.0.3
+-e git+https://github.com/edx-olive/django-ses.git@adjust-django-dependency#django-ses
 django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -30,7 +30,7 @@ django-oauth-toolkit==0.10.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.6
 django-sekizai==0.8.2
--e git+https://github.com/edx-olive/django-ses.git@adjust-django-dependency#django-ses
+-e git+https://github.com/edx-olive/django-ses.git@adjust-django-dependency#egg=django-ses
 django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -30,7 +30,7 @@ django-oauth-toolkit==0.10.0
 django-pipeline-forgiving==1.0.0
 django-pyfs==1.0.6
 django-sekizai==0.8.2
-django-ses==0.7.1
+django-ses==1.0.3
 django-simple-history==1.6.3
 django-statici18n==1.4.0
 django-storages==1.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -8,6 +8,8 @@ beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
 bleach==1.4
 html5lib==0.999
+# SE-4333: We need a urllib3 that matches django-ses's requirements
+urllib3==1.25.4
 boto==2.39.0
 celery==3.1.18
 cryptography==1.5.3


### PR DESCRIPTION
This is required to fix the following issue that started happening in April 1st 2021 in our Ginkgo instance, when sending e-mails:
```
  <Error>
    <Type>Sender</Type>
    <Code>InvalidClientTokenId</Code>
    <Message>Signature Version 3 requests are deprecated from March 1, 2021. From that date on, we are progressively rejecting such requests. To resolve the issue you must migrate to Signature Version 4. If you are self-signing your requests, refer to the documentation for Authenticating requests to the Amazon SES API [1] with Signature Version 4 [2]. If you are not self-signing your requests, simply update your SDK/CLI to the latest version. [1] https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-ses-api-authentication.html [2] https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html</Message>
  </Error>
```

It's due to a progressive deprecation of version 3. The errors seems to happen in a high percentage of attempts, increasily growing, but not 100% yet.
The e-mail *is sent* but the AWS error makes the code crash, so the next lines of code won't run (creating CCX course, enrolling users, etc.) which makes this issue confusing. 

The solution is to use boto3 instead of boto, mainly by upgrading django-ses.

Notes:
 - v1.0.3 is the latest django-ses v1 version as of now, and it seems to support v4
 - there's `boto==2.39` before and after this change. The PR doesn't change this line. But it isn't relevant, since django-ses v1.0.3 uses `boto3`, not `boto`
 - 1.0.3 literally requires: `install_requires=["boto3>=1.0.0", "pytz>=2016.10", "future>=0.16.0", "django>1.10"],`. Campus uses `django==1.8.18`. This created a conflict, so this PR uses a modified django-ses version that doesn't require >1.10
- in addition it needs to pin urllib3 because some packages were keeping it at an old version, and we saw `ImportError: No module named connection` errors

Testing:
- tested on stage by us and Campus. E-mails work, no errors logged
- we built a new AMI to verify it builds