### PR TITLE
Make circleci use constraints file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,13 @@ jobs:
             source /tmp/workspace/venv/bin/activate
 
             # All files listed here must be included in the cache key for pip packages.
-            pip install --exists-action w -r requirements/edx/pre.txt
-            pip install --exists-action w -r requirements/edx/paver.txt
-            pip install --exists-action w -r requirements/edx/github.txt || EXIT=1
-            pip install --exists-action w -r requirements/edx/github.txt # recommender-xblock installation fails first time; so try again.
-            pip install --exists-action w -r requirements/edx/base.txt
-            pip install --exists-action w -r requirements/edx/local.txt
-            pip install --exists-action w -r requirements/edx/post.txt
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/pre.txt
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/paver.txt
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/github.txt || EXIT=1
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/github.txt # recommender-xblock installation fails first time; so try again.
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/base.txt
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/local.txt
+            pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/post.txt
 
       - persist_to_workspace:
           root: /tmp/workspace

--- a/circle.yml
+++ b/circle.yml
@@ -12,24 +12,24 @@ dependencies:
     - npm install
 
     - pip install setuptools
-    - pip install --exists-action w -r requirements/edx/paver.txt
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/paver.txt
 
     # Mirror what paver install_prereqs does.
     # After a successful build, CircleCI will
     # cache the virtualenv at that state, so that
     # the next build will not need to install them
     # from scratch again.
-    - pip install --exists-action w -r requirements/edx/pre.txt
-    - pip install --exists-action w -r requirements/edx/github.txt
-    - pip install --exists-action w -r requirements/edx/local.txt
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/pre.txt
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/github.txt
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/local.txt
 
     # HACK: within base.txt stevedore had a
     # dependency on a version range of pbr.
     # Install a version which falls within that range.
     - pip install  --exists-action w pbr==0.9.0
-    - pip install --exists-action w -r requirements/edx/base.txt
-    - pip install --exists-action w -r requirements/edx/paver.txt
-    - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/base.txt
+    - pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/paver.txt
+    - if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -c requirements/edx/constraints.txt -r requirements/edx/post.txt ; fi
 
     - pip install coveralls==1.0
 


### PR DESCRIPTION
This PR ensures that the circleci uses constraints file while package installation.