### PR TITLE
[SE-4370] add submit_problem_grade_report to periodic execution

### DIFF
--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -324,14 +324,14 @@ def submit_calculate_grades_csv(request, course_key, **task_kwargs):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_problem_grade_report(request, course_key):
+def submit_problem_grade_report(request, course_key, **task_kwargs):
     """
     Submits a task to generate a CSV grade report containing problem
     values.
     """
     task_type = 'grade_problems'
     task_class = calculate_problem_grade_report
-    task_input = {}
+    task_input = task_kwargs
     task_key = ""
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -501,12 +501,28 @@ class ProblemGradeReport(object):
             if task_progress.attempted % status_interval == 0:
                 task_progress.update_task_state(extra_meta=current_step)
 
+        upload_filename = _task_input.get('filename', 'problem_grade_report')
+        upload_parent_dir = _task_input.get('upload_parent_dir', '')
+
         # Perform the upload if any students have been successfully graded
         if len(rows) > 1:
-            upload_csv_to_report_store(rows, 'problem_grade_report', course_id, start_date)
+            upload_csv_to_report_store(
+                rows,
+                upload_filename,
+                course_id,
+                start_date,
+                parent_dir=upload_parent_dir,
+            )
+
         # If there are any error rows, write them out as well
         if len(error_rows) > 1:
-            upload_csv_to_report_store(error_rows, 'problem_grade_report_err', course_id, start_date)
+            upload_csv_to_report_store(
+                error_rows,
+                '{}_err'.format(upload_filename),
+                course_id,
+                start_date,
+                parent_dir=upload_parent_dir,
+            )
 
         return task_progress.update_task_state(extra_meta={'step': 'Uploading CSV'})
 

--- a/lms/djangoapps/periodic_instructor_reports/tasks.py
+++ b/lms/djangoapps/periodic_instructor_reports/tasks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 PERIODIC_REPORT_TASKS = {
     "calculate_grades_csv": submit_calculate_grades_csv,
     "calculate_students_features_csv": submit_calculate_students_features_csv,
-    "calculate_problem_grade_report": 
+    "calculate_problem_grade_report": submit_problem_grade_report,
 }
 
 

--- a/lms/djangoapps/periodic_instructor_reports/tasks.py
+++ b/lms/djangoapps/periodic_instructor_reports/tasks.py
@@ -9,13 +9,18 @@ from django.contrib.auth.models import User
 from django.http.request import HttpRequest
 
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from instructor_task.api import submit_calculate_grades_csv, submit_calculate_students_features_csv
+from instructor_task.api import (
+    submit_calculate_grades_csv,
+    submit_calculate_students_features_csv,
+    submit_problem_grade_report,
+)
 
 logger = logging.getLogger(__name__)
 
 PERIODIC_REPORT_TASKS = {
     "calculate_grades_csv": submit_calculate_grades_csv,
     "calculate_students_features_csv": submit_calculate_students_features_csv,
+    "calculate_problem_grade_report": 
 }
 
 


### PR DESCRIPTION
This PR extends the periodic instructor reports execution with `submit_problem_grade_report`. 

**Dependencies**: None

**Screenshots**: 

<img width="820" alt="Screenshot 2021-05-05 at 8 27 29" src="https://user-images.githubusercontent.com/19173947/117104599-bc33e680-ad7c-11eb-892e-b59b86ec5760.png">
<img width="1436" alt="Screenshot 2021-05-05 at 8 27 47" src="https://user-images.githubusercontent.com/19173947/117104601-bd651380-ad7c-11eb-9de5-a1c247b638b1.png">
<img width="707" alt="Screenshot 2021-05-05 at 8 28 08" src="https://user-images.githubusercontent.com/19173947/117104603-bdfdaa00-ad7c-11eb-8ae3-5bb3dea6b3cc.png">

**Sandbox URL**: Test in devstack - Sandbox will be provisioned after approval

**Merge deadline**: ASAP

**Testing instructions**:

0. Clone the devstack (https://github.com/edx-olive/devstack)
1. In `campus-vars.yml` set `EDXAPP_CELERYBEAT_SCHEDULER: 'djcelery.schedulers.DatabaseScheduler'` and `edx_platform_version:gabor/problem-grade-report-kwargs`
2. Run `vagrant up --provision` to provision a new devstack with the configuration above
3. Start app servers with `paver run_all_servers`
4. Navigate to http://localhost:8000/admin/djcelery/periodictask after all servers started
5. Add a new periodic task shown on the screenshot above
6. Wait 1 minute and check `/tmp/edx-s3/grades/2021/05/05/` for the generated reports

**Author notes and concerns**:

1. This PR will have a counterpart in edx-platform

**Reviewers**
- [x] @itsjeyd 