### PR TITLE
[SE-4361] Fixes failing AMI builds

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -174,7 +174,7 @@ nose-exclude
 nose-ignore-docstring
 nose-randomly==1.2.0
 nosexcover==1.0.7
-pa11ycrawler==1.6.2
+pa11ycrawler==1.7.3
 pep8==1.5.7
 PyContracts==1.7.1
 python-subunit==0.0.16

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -40,7 +40,7 @@ django-method-override==0.1.0
 django-user-tasks==0.1.4
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
-git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
+git+https://github.com/edx-unsupported/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
 django==1.8.18
 django-waffle==0.12.0
 djangorestframework-jwt==1.8.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -12,7 +12,7 @@ html5lib==0.999
 urllib3==1.25.4
 boto==2.39.0
 celery==3.1.18
-cryptography==1.5.3
+cryptography==3.3.2
 cssselect==0.9.1
 dealer==2.0.4
 defusedxml==0.4.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -75,7 +75,7 @@ mako==1.0.2
 Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
-meliae==0.4.0
+meliae==0.5.0
 mongoengine==0.10.5
 MySQL-python==1.2.5
 networkx==1.7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -76,7 +76,7 @@ Markdown==2.2.1
 --allow-external meliae
 --allow-unverified meliae
 meliae==0.4.0
-mongoengine==0.10.0
+mongoengine==0.10.5
 MySQL-python==1.2.5
 networkx==1.7
 nose-xunitmp==0.3.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -49,7 +49,7 @@
 django-pipeline==1.5.3  # installation from path or url cannot be constrained to a version
 git+https://github.com/open-craft/django-wiki.git@v0.0.10.1#egg=django-wiki==0.0.10.1
 git+https://github.com/open-craft/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
-git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
+git+https://github.com/edx-olive/MongoDBProxy.git@c3ddf4b1c3e3ae8abdfa60e5f3b2abc1a2c33bf9#egg=MongoDBProxy==0.1.0+edx.2
 git+https://github.com/open-craft/nltk.git@2.0.6#egg=nltk==2.0.6
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/open-craft/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -21,8 +21,5 @@ Cython==0.21.2
 Django==1.8.18
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
 
-# https://github.com/edx/MongoDBProxy setup requirements
-pyandoc
-
 # https://github.com/hmarr/django-debug-toolbar-mongo setup requirements
 versiontools

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -20,3 +20,9 @@ Cython==0.21.2
 # Ginkgo only!
 Django==1.8.18
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6
+
+# https://github.com/edx/MongoDBProxy setup requirements
+pyandoc
+
+# https://github.com/hmarr/django-debug-toolbar-mongo setup requirements
+versiontools


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

AMI builds were failing due to python 2.7 being no longer supported. Although the errors showed up suddenly, they have been addressed by the changes below. 

* `mongoengine`, `meliae`, `pa11ycrawler`, and `cryptography` version update was necessary
* `django-rest-framework` repository owner wasn't necessary to change, but it is beneficial for the future
* Adding new requirement dependencies in the `pre.txt` file is because we kept receiving `Could not find suitable distribution for Requirement` for the setup requirements
* `pyandoc` setup requirement was removed in https://github.com/edx-olive/MongoDBProxy because it was causing more trouble than fixing
  * For more information: When the `pyandoc` isn't added to the `pre.txt`, we get a `Could not find suitable distribution`. However, once added, we get a `OSError: Path to pandoc executable does not exists`. The setup requirement is only used for defining the installed package's readme; therefore, I removed it to provide a quicker fix for the AMIs. 

## Supporting information

* **Jira Tickets**: SE-4361

## Testing instructions

Build a new AMI with this branch and verify the instance using the manual instance checklist. 

## Deadline

ASAP