### PR TITLE
fix: update xblock version to 1.2.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -212,7 +212,7 @@ edx-django-release-util==0.3.0
 
 # Support for plugins
 web-fragments==0.2.2
-xblock==1.0.0
+xblock==1.2.0
 
 # Redis version
 redis==2.10.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 
 beautifulsoup4==4.1.3
 beautifulsoup==3.2.1
-bleach==1.4
+bleach==2.0.0
 html5lib==0.999
 # SE-4333: We need a urllib3 that matches django-ses's requirements
 urllib3==1.25.4


### PR DESCRIPTION
### Description

Update XBlock and bleach to avoid version incompatibility.

Due to the translation [update of xblock poll](https://github.com/edx-olive/edx-platform/commit/25f9e6643ffab712118c2e3cd5092a713f2b955a) some time ago, stage (and probably prod) got "silently" broken as no issues raised until the poll related xblock is loaded. Xblock-Poll requires Xblock v1.2.0 instead of v.1.0.0 so we need to install that instead. As no breaking changes were introduced in 1.2.0, this is considered a low-risk change.

On the other hand, the xblock-poll package does not define which exact version of `bleach` package is required but uses features from >=2.0.0 that is pinned to 1.4 in edx-platform. We could choose to a) pin bleach in the package or b) pin the package in edx-platform. As pinning `bleach` in the poll package won't have any effect, we pin `bleach` in edx-platform.

Issue traceback

```
 File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py", line 132, in _load_item
    class_ = self.load_block_type(block_data.block_type)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1449, in load_block_type
    return super(DescriptorSystem, self).load_block_type(block_type)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 604, in load_block_type
    return XBlock.load_class(block_type, self.default_class, self.select)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 120, in load_class
    PLUGIN_CACHE[key] = cls._load_class_entry_point(selected_entry_point)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/plugin.py", line 75, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2442, in load
    self.require(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2465, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
VersionConflict: (XBlock 1.0.0 (/edx/app/edxapp/venvs/edxapp/lib/python2.7/site-packages), Requirement.parse('XBlock>=1.2'))
```