### PR TITLE
[SE-4304] feat: add upload folder prefix

### DIFF
--- a/lms/djangoapps/periodic_instructor_reports/tasks.py
+++ b/lms/djangoapps/periodic_instructor_reports/tasks.py
@@ -58,6 +58,7 @@ def periodic_task_wrapper(course_ids, *args, **kwargs):
 
     include_related_ccx = kwargs.get("include_ccx", False)
     only_ccx = kwargs.get("only_ccx", False)
+    upload_folder_prefix = kwargs.get("upload_folder_prefix", "")
     use_folders_by_date = kwargs.get("use_folders_by_date", False)
     filename = kwargs.get("filename", None)
 
@@ -85,7 +86,14 @@ def periodic_task_wrapper(course_ids, *args, **kwargs):
 
         if use_folders_by_date:
             task_kwargs.update({
-                "upload_parent_dir": date.today().strftime("%Y/%m/%d")
+                "upload_parent_dir": "{prefix}{folder}".format(
+                    prefix=upload_folder_prefix,
+                    folder=date.today().strftime("%Y/%m/%d")
+                )
+            })
+        elif upload_folder_prefix:
+            task_kwargs.update({
+                "upload_parent_dir": upload_folder_prefix
             })
 
         logger.info('Calling periodic "%s" for course "%s"', task_name, course_id)


### PR DESCRIPTION
Implement additional folder structure options. This way, users could introduce as many custom subfolders into the S3 folder structure as they need to automate their processes.

**Dependencies**: None

**Screenshots**:  N/A

**Sandbox URL**: https://studio.stage.campus.gov.il/admin/

**Merge deadline**: ASAP

**Testing instructions**:

* Enable task https://courses.stage.campus.gov.il/admin/djcelery/periodictask/4/
* Wait for the time period (about 1 minute)
* Go to https://courses.stage.campus.gov.il/admin/instructor_task/instructortask/?o=-6
* Check for the latest 5 runs for:
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@29
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@28
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@23
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@19
  * course-v1:OpenCraft+CS101+2020_T1
* Check for the related reports within the SE-4304 folder on S3 in the [corresponding grades bucket](https://s3.console.aws.amazon.com/s3/buckets/stage-olivex-student-grades?prefix=stage%2FSE-4304%2F&region=eu-west-1)
* Disable the periodic task https://courses.stage.campus.gov.il/admin/djcelery/periodictask/4/

**Author notes and concerns**:

N/A

**Reviewers**

- [ ] @itsjeyd 
- [ ] @pkulkark 