### PR TITLE
fix: add ENABLE_COURSE_FILENAME_CCX_SUFFIX to lms

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -399,6 +399,17 @@ FEATURES = {
     # Show sensitive data msg when downloading reports
     'ENABLE_SENSITIVE_DATA_MSG_ON_DASHBOARD': False,
     'DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS': False,
+
+    # .. toggle_name: FEATURES['ENABLE_COURSE_FILENAME_CCX_SUFFIX']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: If set to True, CCX ID will be included in the generated filename for CCX courses.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-03-16
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: None
+    # .. toggle_warnings: Turning this feature ON will affect all generated filenames which are related to CCX courses.
+    'ENABLE_COURSE_FILENAME_CCX_SUFFIX': False
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews


### PR DESCRIPTION
The enable course filename ccx suffix setting was missing from LMS common settings. This PR ensures that the setting is added to the default values.

**Dependencies**: None

**Related PRs**:

- https://github.com/edx-olive/configuration/pull/25
- https://github.com/edx-olive/olive-secure/pull/187

**Screenshots**: N/A

**Sandbox URL**: N/A

**Merge deadline**: None

**Testing instructions**:

* Proofread the changes

**Author notes and concerns**:

Since this setting is set by the olivex-secure config  branch, this PR is not a requirement but a nice to have

**Reviewers**
- [ ] TBD