### PR TITLE
[SE-4304] chore: add single-beat for celerybeat scheduling

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -220,3 +220,6 @@ redis==2.10.6
 # Third Party XBlocks
 # this is edx-sga 0.6.2 with extra patches
 -e git+https://github.com/open-craft/edx-sga.git@opencraft-release/ginkgo.2-campus#egg=edx-sga==0.6.2
+
+# Single beat for configuring a single celerybeat scheduler
+single-beat==0.4.2


### PR DESCRIPTION
This PR adds [`single-beat`](https://github.com/ybrs/single-beat) to the platform requirements used by the [configuration](https://github.com/edx-olive/configuration/pull/31).

**Sandbox URL**: Deployed to stage

**Merge deadline**: ASAP

**Testing instructions**:

* Scale stage worker instances up to 10
* Enable task https://courses.stage.campus.gov.il/admin/djcelery/periodictask/4/
* Wait for the time period (about 1 minute)
* Go to https://courses.stage.campus.gov.il/admin/instructor_task/instructortask/?o=-6
* Check for the latest 5 runs for:
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@29
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@28
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@23
  * ccx-v1:OpenCraft+CS101+2020_T1+ccx@19
  * course-v1:OpenCraft+CS101+2020_T1
* Check for the related reports within the SE-4304 folder on S3 in the [corresponding grades bucket](https://s3.console.aws.amazon.com/s3/buckets/stage-olivex-student-grades?prefix=stage%2FSE-4304%2F&region=eu-west-1)
* Repeat the above process (without scaling) 3 times with 2 minutes delay between each iteration

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @itsjeyd 
- [ ] @pkulkark 