### PR TITLE
fix: ensure task is not complaining on course IDs

### DIFF
--- a/lms/djangoapps/periodic_instructor_reports/tasks.py
+++ b/lms/djangoapps/periodic_instructor_reports/tasks.py
@@ -68,7 +68,7 @@ def periodic_task_wrapper(course_ids, *args, **kwargs):
         try:
             course_ids.append(SlashSeparatedCourseKey.from_deprecated_string(course_id))
         except Exception as exc:
-            logger.error("cannot get course from key for %s: %s" % (course_id, str(exc)))
+            logger.error("Course not found for course id %s: %s" % (course_id, str(exc)))
 
     if include_related_ccx:
         custom_courses = CustomCourseForEdX.objects.filter(course_id__in=course_ids)

--- a/lms/djangoapps/periodic_instructor_reports/tasks.py
+++ b/lms/djangoapps/periodic_instructor_reports/tasks.py
@@ -62,10 +62,13 @@ def periodic_task_wrapper(course_ids, *args, **kwargs):
     use_folders_by_date = kwargs.get("use_folders_by_date", False)
     filename = kwargs.get("filename", None)
 
-    course_ids = [
-        SlashSeparatedCourseKey.from_deprecated_string(course_id)
-        for course_id in course_ids
-    ]
+    course_ids = []
+
+    for course_id in course_ids:
+        try:
+            course_ids.append(SlashSeparatedCourseKey.from_deprecated_string(course_id))
+        except Exception as exc:
+            logger.error("cannot get course from key for %s: %s" % (course_id, str(exc)))
 
     if include_related_ccx:
         custom_courses = CustomCourseForEdX.objects.filter(course_id__in=course_ids)


### PR DESCRIPTION
## Description

`InvalidKeyError` - `opaque_keys:InvalidKeyErrorperiodic_instructor_reports.tasks.periodic_task_wrapper` raised when a course ID is not found in the batch of courses marked for processing.

This issue causes missing reports for all the other courses that are in the same batch with the mentioned course ID. So, if 15 more course IDs are put into the same batch, none of them will produce reports.

## Testing instructions

**Locally:**

Follow the testing instructions of https://github.com/edx-olive/edx-platform/pull/59 but add an invalid course ID as well to ensure we are filtering for working course IDs only.